### PR TITLE
Add name parameter to new-tab API

### DIFF
--- a/MaQuake/Sources/MaQuake/API/ControlServer.swift
+++ b/MaQuake/Sources/MaQuake/API/ControlServer.swift
@@ -244,6 +244,9 @@ final class ControlServer {
         let dir = json["directory"] as? String
         wc.tabManager.addTab(in: dir)
         let tab = wc.tabManager.tabs.last!
+        if let name = json["name"] as? String, !name.isEmpty {
+            wc.tabManager.renameTab(id: tab.id, name: name)
+        }
         return jsonOK(["session_id": tab.id.uuidString])
     }
 

--- a/MaQuake/Sources/MaQuake/MCP/MCPHTTPServer.swift
+++ b/MaQuake/Sources/MaQuake/MCP/MCPHTTPServer.swift
@@ -299,11 +299,12 @@ final class MCPHTTPServer {
              inputSchema: .object(["type": .string("object"), "properties": .object([:])]) ),
         Tool(name: "unpin", description: "Unpin the terminal (auto-hide on focus loss)",
              inputSchema: .object(["type": .string("object"), "properties": .object([:])]) ),
-        Tool(name: "new_tab", description: "Create a new terminal tab, optionally in a given directory",
+        Tool(name: "new_tab", description: "Create a new terminal tab. Returns session_id of the new session.",
              inputSchema: .object([
                 "type": .string("object"),
                 "properties": .object([
-                    "directory": .object(["type": .string("string"), "description": .string("Working directory for the new tab")])
+                    "directory": .object(["type": .string("string"), "description": .string("Working directory for the new tab")]),
+                    "name": .object(["type": .string("string"), "description": .string("Tab title (overrides auto-detected title)")])
                 ])
              ])),
         Tool(name: "focus", description: "Focus a tab (by session_id/index), a pane (by pane_id), or navigate panes (direction: next/prev)",

--- a/MaQuake/Tests/MaQuakeTests/ControlServerTests.swift
+++ b/MaQuake/Tests/MaQuakeTests/ControlServerTests.swift
@@ -197,6 +197,32 @@ struct ControlServerHandlerTests {
         #expect(wc.tabManager.tabs.count == 2)
     }
 
+    @Test func newTab_withName_setsCustomTitle() {
+        let (server, wc) = makeServer()
+        let result = server.handleRequest(json(["action": "new-tab", "name": "Dev Server"]))
+        let parsed = parse(result)
+        #expect(parsed?["ok"] as? Bool == true)
+        #expect(wc.tabManager.tabs.last?.customTitle == "Dev Server")
+        #expect(wc.tabManager.tabs.last?.displayTitle == "Dev Server")
+    }
+
+    @Test func newTab_withEmptyName_doesNotSetTitle() {
+        let (server, wc) = makeServer()
+        let result = server.handleRequest(json(["action": "new-tab", "name": ""]))
+        let parsed = parse(result)
+        #expect(parsed?["ok"] as? Bool == true)
+        #expect(wc.tabManager.tabs.last?.customTitle == nil)
+    }
+
+    @Test func newTab_withNameAndDirectory_setsBoth() {
+        let (server, wc) = makeServer()
+        let result = server.handleRequest(json(["action": "new-tab", "name": "Logs", "directory": "/tmp"]))
+        let parsed = parse(result)
+        #expect(parsed?["ok"] as? Bool == true)
+        #expect(wc.tabManager.tabs.last?.customTitle == "Logs")
+        #expect(wc.tabManager.tabs.count == 2)
+    }
+
     // MARK: - focus
 
     @Test func focus_bySessionID_selectsTab() {


### PR DESCRIPTION
## Summary
- Adds optional `name` parameter to the `new-tab` socket API and MCP tool
- When provided, sets the tab's custom title immediately after creation
- Empty string is ignored (no-op)

Closes #3

## Test plan
- [ ] `new-tab` with `name` sets tab title
- [ ] `new-tab` with empty `name` does not set title
- [ ] `new-tab` with `name` + `directory` sets both
- [ ] 3 unit tests added in ControlServerTests