### PR TITLE
Add disable-animation toggle and allow 100% height

### DIFF
--- a/MaQuake/Sources/MaQuake/Settings/SettingsView.swift
+++ b/MaQuake/Sources/MaQuake/Settings/SettingsView.swift
@@ -13,6 +13,7 @@ struct SettingsView: View {
     @AppStorage("mcpAccess") private var mcpAccess: String = "ask"
     @AppStorage("confirmOnQuit") private var confirmOnQuit: Bool = false
     @AppStorage("restoreTabsOnLaunch") private var restoreTabsOnLaunch: Bool = true
+    @AppStorage("disableAnimation") private var disableAnimation: Bool = false
     @AppStorage("shellPath") private var shellPath: String = ""
     @State private var customShellPath: String = ""
     @State private var isCustomShell: Bool = false
@@ -68,6 +69,10 @@ struct SettingsView: View {
                         }
                         HStack {
                             Toggle("Restore tabs on launch", isOn: $restoreTabsOnLaunch)
+                            Spacer()
+                        }
+                        HStack {
+                            Toggle("Disable animation", isOn: $disableAnimation)
                             Spacer()
                         }
                     }
@@ -246,7 +251,7 @@ struct SettingsView: View {
                                     get: { Double(windowController.heightPercent) },
                                     set: { windowController.setHeightPercent(Int($0)) }
                                 ),
-                                in: 20...90,
+                                in: 20...100,
                                 step: 5
                             )
                             Text("\(windowController.heightPercent)%")

--- a/MaQuake/Sources/MaQuake/Window/WindowController.swift
+++ b/MaQuake/Sources/MaQuake/Window/WindowController.swift
@@ -388,8 +388,12 @@ final class WindowController: ObservableObject {
         panel.makeKeyAndOrderFront(nil)
         NSApp.activate(ignoringOtherApps: true)
 
-        withAnimation(.spring(response: 0.42, dampingFraction: 0.8, blendDuration: 0)) {
+        if UserDefaults.standard.bool(forKey: "disableAnimation") {
             state = .visible
+        } else {
+            withAnimation(.spring(response: 0.42, dampingFraction: 0.8, blendDuration: 0)) {
+                state = .visible
+            }
         }
 
         // Focus the terminal view after show
@@ -401,13 +405,18 @@ final class WindowController: ObservableObject {
     func hide() {
         guard state == .visible else { return }
 
-        withAnimation(.spring(response: 0.45, dampingFraction: 1.0, blendDuration: 0)) {
+        if UserDefaults.standard.bool(forKey: "disableAnimation") {
             state = .hidden
+        } else {
+            withAnimation(.spring(response: 0.45, dampingFraction: 1.0, blendDuration: 0)) {
+                state = .hidden
+            }
         }
         panel.ignoresMouseEvents = true
 
-        // After spring animation settles — activate previous app
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { [weak self] in
+        // After animation settles (or immediately) — activate previous app
+        let delay = UserDefaults.standard.bool(forKey: "disableAnimation") ? 0.05 : 0.5
+        DispatchQueue.main.asyncAfter(deadline: .now() + delay) { [weak self] in
             guard let self, self.state == .hidden else { return }
             if let prev = self.previousApp, !prev.isTerminated {
                 prev.activate()
@@ -420,7 +429,7 @@ final class WindowController: ObservableObject {
     func updateHeightByDelta(_ pixelHeight: CGFloat) {
         let screen = resolvedScreen.frame
         let pct = Int((pixelHeight / screen.height) * 100)
-        let clamped = min(max(pct, 20), 90)
+        let clamped = min(max(pct, 20), 100)
         heightPercent = clamped
         savedHeightPercent = clamped
     }
@@ -441,7 +450,7 @@ final class WindowController: ObservableObject {
     }
 
     func setHeightPercent(_ percent: Int) {
-        heightPercent = min(max(percent, 20), 90)
+        heightPercent = min(max(percent, 20), 100)
         savedHeightPercent = heightPercent
     }
 

--- a/MaQuake/Tests/MaQuakeTests/WindowControllerResizeTests.swift
+++ b/MaQuake/Tests/MaQuakeTests/WindowControllerResizeTests.swift
@@ -48,10 +48,10 @@ struct WindowControllerPercentClampingTests {
         #expect(wc.heightPercent == 20)
     }
 
-    @Test func setHeightPercent_aboveMax_clampedTo90() {
+    @Test func setHeightPercent_aboveMax_clampedTo100() {
         let wc = WindowController()
-        wc.setHeightPercent(95)
-        #expect(wc.heightPercent == 90)
+        wc.setHeightPercent(110)
+        #expect(wc.heightPercent == 100)
     }
 
     @Test func setHeightPercent_atMin_exact20() {
@@ -60,10 +60,10 @@ struct WindowControllerPercentClampingTests {
         #expect(wc.heightPercent == 20)
     }
 
-    @Test func setHeightPercent_atMax_exact90() {
+    @Test func setHeightPercent_atMax_exact100() {
         let wc = WindowController()
-        wc.setHeightPercent(90)
-        #expect(wc.heightPercent == 90)
+        wc.setHeightPercent(100)
+        #expect(wc.heightPercent == 100)
     }
 
     @Test func setHeightPercent_normalValue_setsExactly() {
@@ -92,10 +92,10 @@ struct WindowControllerPercentClampingTests {
         #expect(wc.heightPercent == 20)
     }
 
-    @Test func setHeightPercent_91_clampedTo90() {
+    @Test func setHeightPercent_101_clampedTo100() {
         let wc = WindowController()
-        wc.setHeightPercent(91)
-        #expect(wc.heightPercent == 90)
+        wc.setHeightPercent(101)
+        #expect(wc.heightPercent == 100)
     }
 }
 
@@ -132,11 +132,55 @@ struct WindowControllerDeltaResizeTests {
         #expect(wc.heightPercent >= 20)
     }
 
-    @Test func updateHeightByDelta_fullHeight_clampedTo90() {
+    @Test func updateHeightByDelta_fullHeight_clampedTo100() {
         let wc = WindowController()
         let screenHeight = wc.resolvedScreen.frame.height
         wc.updateHeightByDelta(screenHeight * 2)
-        #expect(wc.heightPercent == 90)
+        #expect(wc.heightPercent == 100)
+    }
+}
+
+@MainActor
+@Suite(.serialized)
+struct WindowControllerAnimationTests {
+
+    @Test func show_withAnimationDisabled_changesStateInstantly() {
+        UserDefaults.standard.set(true, forKey: "disableAnimation")
+        defer { UserDefaults.standard.removeObject(forKey: "disableAnimation") }
+
+        let wc = WindowController()
+        #expect(wc.state == .hidden)
+        wc.show()
+        #expect(wc.state == .visible)
+    }
+
+    @Test func hide_withAnimationDisabled_changesStateInstantly() {
+        UserDefaults.standard.set(true, forKey: "disableAnimation")
+        defer { UserDefaults.standard.removeObject(forKey: "disableAnimation") }
+
+        let wc = WindowController()
+        wc.show()
+        #expect(wc.state == .visible)
+        wc.hide()
+        #expect(wc.state == .hidden)
+    }
+
+    @Test func toggle_withAnimationDisabled_worksCorrectly() {
+        UserDefaults.standard.set(true, forKey: "disableAnimation")
+        defer { UserDefaults.standard.removeObject(forKey: "disableAnimation") }
+
+        let wc = WindowController()
+        wc.toggle()
+        #expect(wc.state == .visible)
+        wc.toggle()
+        #expect(wc.state == .hidden)
+    }
+
+    @Test func heightPercent_allowsFullScreen() {
+        let wc = WindowController()
+        wc.setHeightPercent(100)
+        #expect(wc.heightPercent == 100)
+        #expect(wc.terminalSize.height > 0)
     }
 }
 


### PR DESCRIPTION
## Summary
- Add "Disable animation" toggle in Settings > General - instant show/hide without spring animation
- Raise height slider cap from 90% to 100% for full-screen height
- Tab switching presets (⌘←/→) were already added in a previous change

Closes #1

## Test plan
- [ ] Toggle "Disable animation" in Settings - show/hide should be instant
- [ ] Height slider goes to 100%
- [ ] 4 new unit tests, 3 existing updated for new height cap