### PR TITLE
Replace tab switch presets with configurable shortcuts

### DIFF
--- a/MaQuake/Sources/MaQuake/Settings/HelpView.swift
+++ b/MaQuake/Sources/MaQuake/Settings/HelpView.swift
@@ -1,10 +1,8 @@
 import SwiftUI
-import KeyboardShortcuts
 
 struct HelpView: View {
     private let version = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "dev"
     private let build = Bundle.main.object(forInfoDictionaryKey: "CFBundleVersion") as? String ?? "-"
-
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 16) {
@@ -41,7 +39,7 @@ struct HelpView: View {
                         shortcutRow("New tab", "⌘ T")
                         shortcutRow("Close tab", "⌘ W")
                         shortcutRow("Reopen closed tab", "⌘ ⇧ T")
-                        shortcutRow("Next / Previous tab", "⌘ ⇧ ]  /  ⌘ ⇧ [")
+                        shortcutRow("Next / Previous tab", "⌘ ⇧ ]  /  ⌘ ⇧ [  (configurable in Settings)")
                         shortcutRow("Go to tab 1–9", "⌘ 1 – ⌘ 9")
                         shortcutRow("Rename tab", "Double-click title")
                     }

--- a/MaQuake/Sources/MaQuake/Settings/SettingsView.swift
+++ b/MaQuake/Sources/MaQuake/Settings/SettingsView.swift
@@ -4,6 +4,8 @@ import KeyboardShortcuts
 
 extension KeyboardShortcuts.Name {
     static let toggleTerminal = Self("toggleTerminal", default: .init(.space, modifiers: .option))
+    static let nextTab = Self("nextTab", default: .init(.rightBracket, modifiers: [.command, .shift]))
+    static let previousTab = Self("previousTab", default: .init(.leftBracket, modifiers: [.command, .shift]))
 }
 
 struct SettingsView: View {
@@ -217,10 +219,23 @@ struct SettingsView: View {
                     .padding(8)
                 }
 
-                GroupBox("Hotkey") {
-                    HStack {
-                        KeyboardShortcuts.Recorder("Toggle Terminal:", name: .toggleTerminal)
-                        Spacer()
+                GroupBox("Keyboard") {
+                    VStack(alignment: .leading, spacing: 8) {
+                        HStack {
+                            KeyboardShortcuts.Recorder("Toggle Terminal:", name: .toggleTerminal)
+                            Spacer()
+                        }
+                        HStack {
+                            KeyboardShortcuts.Recorder("Next Tab:", name: .nextTab)
+                            Spacer()
+                        }
+                        HStack {
+                            KeyboardShortcuts.Recorder("Previous Tab:", name: .previousTab)
+                            Spacer()
+                        }
+                        Text("Ctrl+Tab and ⌘1-9 are always available.")
+                            .font(.caption)
+                            .foregroundColor(.secondary)
                     }
                     .padding(8)
                 }

--- a/MaQuake/Sources/MaQuake/Window/WindowController.swift
+++ b/MaQuake/Sources/MaQuake/Window/WindowController.swift
@@ -1,5 +1,6 @@
 import AppKit
 import SwiftUI
+import KeyboardShortcuts
 
 enum PanelState: Equatable {
     case hidden
@@ -222,6 +223,16 @@ final class WindowController: ObservableObject {
 
             guard cmd else { return event }
 
+            // Configurable next/prev tab shortcuts (via KeyboardShortcuts recorder)
+            if self.eventMatchesShortcut(event, for: .nextTab) {
+                self.tabManager.selectNextTab()
+                return nil
+            }
+            if self.eventMatchesShortcut(event, for: .previousTab) {
+                self.tabManager.selectPreviousTab()
+                return nil
+            }
+
             // ⌘1-8 → select tab N, ⌘9 → last tab (Chrome behavior)
             if !shift, let digit = Self.digitKeyCodes[key] {
                 if digit == 9 {
@@ -264,12 +275,6 @@ final class WindowController: ObservableObject {
             case Self.kVK_Comma where !shift:
                 self.openSettings()
                 return nil
-            case Self.kVK_LeftBracket where shift:
-                self.tabManager.selectPreviousTab()
-                return nil
-            case Self.kVK_RightBracket where shift:
-                self.tabManager.selectNextTab()
-                return nil
             case Self.kVK_LeftBracket where !shift:
                 // ⌘[ → previous pane
                 self.tabManager.moveFocusInActiveTab(.previous)
@@ -296,6 +301,16 @@ final class WindowController: ObservableObject {
 
             return event
         }
+    }
+
+    private func eventMatchesShortcut(_ event: NSEvent, for name: KeyboardShortcuts.Name) -> Bool {
+        guard let shortcut = KeyboardShortcuts.getShortcut(for: name) else { return false }
+        let keyMatch = event.keyCode == UInt16(shortcut.carbonKeyCode)
+        let modMatch = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
+            .subtracting(.numericPad)
+            .subtracting(.function)
+            == shortcut.modifiers.intersection(.deviceIndependentFlagsMask)
+        return keyMatch && modMatch
     }
 
     // MARK: - Mouse Monitors

--- a/MaQuake/Tests/MaQuakeTests/UIComponentTests.swift
+++ b/MaQuake/Tests/MaQuakeTests/UIComponentTests.swift
@@ -1,5 +1,6 @@
 import Testing
 import AppKit
+import KeyboardShortcuts
 @testable import Macuake
 
 /// Comprehensive UI component tests covering tab interactions, keyboard shortcuts,
@@ -89,6 +90,44 @@ struct UIComponentTests {
         #expect(wc.tabManager.activeTabIndex == 0)
     }
 
+    // MARK: - Tab switching (KeyboardShortcuts recorder)
+
+    @Test func tabSwitch_selectNextPrev_wrapsAround() {
+        let wc = makeController()
+        wc.tabManager.addTab()
+        wc.tabManager.addTab()
+        wc.tabManager.selectTab(at: 0)
+
+        wc.tabManager.selectNextTab()
+        #expect(wc.tabManager.activeTabIndex == 1)
+        wc.tabManager.selectNextTab()
+        #expect(wc.tabManager.activeTabIndex == 2)
+        wc.tabManager.selectNextTab()
+        #expect(wc.tabManager.activeTabIndex == 0)
+
+        wc.tabManager.selectPreviousTab()
+        #expect(wc.tabManager.activeTabIndex == 2)
+        wc.tabManager.selectPreviousTab()
+        #expect(wc.tabManager.activeTabIndex == 1)
+    }
+
+    @Test func tabSwitch_singleTab_doesNothing() {
+        let wc = makeController()
+        #expect(wc.tabManager.tabs.count == 1)
+        #expect(wc.tabManager.activeTabIndex == 0)
+
+        wc.tabManager.selectNextTab()
+        #expect(wc.tabManager.activeTabIndex == 0)
+        wc.tabManager.selectPreviousTab()
+        #expect(wc.tabManager.activeTabIndex == 0)
+    }
+
+    @Test func keyboardShortcutNames_areDefined() {
+        #expect(KeyboardShortcuts.Name.toggleTerminal.rawValue == "toggleTerminal")
+        #expect(KeyboardShortcuts.Name.nextTab.rawValue == "nextTab")
+        #expect(KeyboardShortcuts.Name.previousTab.rawValue == "previousTab")
+    }
+
     // MARK: - Tab creation (Cmd+T)
 
     @Test func cmdT_createsNewTab_andActivatesIt() {
@@ -176,7 +215,7 @@ struct UIComponentTests {
 
     @Test func renameTab_invalidID_doesNothing() {
         let wc = makeController()
-        let fakeID = UUID()
+        let fakeID = generateShortID()
         wc.tabManager.renameTab(id: fakeID, name: "Should Not Appear")
         #expect(wc.tabManager.tabs.allSatisfy { $0.customTitle == nil })
     }
@@ -707,13 +746,13 @@ struct PaneNodeTests {
 
     @Test func leaf_leafCount_isOne() {
         let instance = TerminalInstance()
-        let node = PaneNode.leaf(id: UUID(), backend: instance.backend)
+        let node = PaneNode.leaf(id: generateShortID(), backend: instance.backend)
         #expect(node.leafCount == 1)
         instance.terminate()
     }
 
     @Test func leaf_leafIDs_containsSelf() {
-        let id = UUID()
+        let id = generateShortID()
         let instance = TerminalInstance()
         let node = PaneNode.leaf(id: id, backend: instance.backend)
         #expect(node.leafIDs == [id])
@@ -721,11 +760,11 @@ struct PaneNodeTests {
     }
 
     @Test func leaf_instanceLookup() {
-        let id = UUID()
+        let id = generateShortID()
         let instance = TerminalInstance()
         let node = PaneNode.leaf(id: id, backend: instance.backend)
         #expect(node.backend(for: id) === instance.backend)
-        #expect(node.backend(for: UUID()) == nil)
+        #expect(node.backend(for: generateShortID()) == nil)
         instance.terminate()
     }
 
@@ -733,10 +772,10 @@ struct PaneNodeTests {
         let i1 = TerminalInstance()
         let i2 = TerminalInstance()
         let node = PaneNode.split(
-            id: UUID(),
+            id: generateShortID(),
             axis: .horizontal,
-            first: .leaf(id: UUID(), backend: i1.backend),
-            second: .leaf(id: UUID(), backend: i2.backend),
+            first: .leaf(id: generateShortID(), backend: i1.backend),
+            second: .leaf(id: generateShortID(), backend: i2.backend),
             ratio: 0.5
         )
         #expect(node.leafCount == 2)
@@ -745,12 +784,12 @@ struct PaneNodeTests {
     }
 
     @Test func split_leafIDs_containsBoth() {
-        let id1 = UUID()
-        let id2 = UUID()
+        let id1 = generateShortID()
+        let id2 = generateShortID()
         let i1 = TerminalInstance()
         let i2 = TerminalInstance()
         let node = PaneNode.split(
-            id: UUID(),
+            id: generateShortID(),
             axis: .horizontal,
             first: .leaf(id: id1, backend: i1.backend),
             second: .leaf(id: id2, backend: i2.backend),


### PR DESCRIPTION
## Summary
- Removed `TabSwitchPreset` enum and hardcoded ⌘⇧[/] tab switching
- Added `KeyboardShortcuts.Recorder` for Next Tab and Previous Tab in Settings
- Default shortcuts remain ⌘⇧] / ⌘⇧[ but users can rebind to any combo
- Fixes usability on non-English layouts (French AZERTY, German QWERTZ, etc.) where bracket keys require dead-key sequences

Partially addresses #1 (tab switching shortcuts item).

## Test plan
- [ ] Verify default ⌘⇧[ and ⌘⇧] still switch tabs
- [ ] Open Settings > Keyboard and rebind Next/Previous Tab to custom keys
- [ ] Verify custom shortcuts work after rebinding
- [ ] Verify Ctrl+Tab and ⌘1-9 still work independently
- [ ] Test on non-English keyboard layout (e.g. French) - bracket keys should be rebindable
