### PR TITLE
Update GhosttyKit to v1.3.1

### DIFF
--- a/MaQuake/Sources/MaQuake/Terminal/GhosttyApp.swift
+++ b/MaQuake/Sources/MaQuake/Terminal/GhosttyApp.swift
@@ -104,9 +104,8 @@ final class GhosttyApp: @unchecked Sendable {
 
         runtimeConfig.read_clipboard_cb = { _, _, state in
             let contents = NSPasteboard.general.string(forType: .string) ?? ""
-            // Must find the surface to complete the request — route via app userdata
-            // For now, complete on the first available backend
             GhosttyApp.shared.completeClipboardRead(contents: contents, state: state)
+            return true
         }
 
         runtimeConfig.confirm_read_clipboard_cb = { _, _, state, _ in

--- a/scripts/build-install.sh
+++ b/scripts/build-install.sh
@@ -38,6 +38,12 @@ for bundle in .build/apple/Products/Release/*.bundle; do
     echo "    $name"
 done
 
+echo "==> Removing stale bundles from app root..."
+for bundle in "$APP_BUNDLE"/*.bundle; do
+    [ -d "$bundle" ] || continue
+    rm -rf "$bundle"
+done
+
 echo "==> Embedding Sparkle.framework..."
 FRAMEWORKS_DIR="$APP_BUNDLE/Contents/Frameworks"
 mkdir -p "$FRAMEWORKS_DIR"
@@ -81,12 +87,15 @@ codesign --force --sign "$SIGNING_IDENTITY" \
 codesign --verify --deep --strict "$APP_BUNDLE"
 echo "==> Signed and verified: $APP_BUNDLE"
 
-# Always install: kill running instance, force-replace, relaunch
-echo "==> Installing to /Applications..."
-killall Macuake 2>/dev/null || true
+# Install as Macuake_dev.app to avoid conflicting with brew-installed Macuake.app
+INSTALL_NAME="Macuake_dev"
+echo "==> Installing to /Applications/${INSTALL_NAME}.app..."
+killall "$INSTALL_NAME" 2>/dev/null || true
 sleep 0.3
-rm -rf /Applications/Macuake.app
-cp -R "$APP_BUNDLE" /Applications/Macuake.app
-echo "==> Installed: /Applications/Macuake.app"
+rm -rf "/Applications/${INSTALL_NAME}.app"
+cp -R "$APP_BUNDLE" "/Applications/${INSTALL_NAME}.app"
+mv "/Applications/${INSTALL_NAME}.app/Contents/MacOS/Macuake" "/Applications/${INSTALL_NAME}.app/Contents/MacOS/${INSTALL_NAME}"
+/usr/libexec/PlistBuddy -c "Set :CFBundleExecutable ${INSTALL_NAME}" "/Applications/${INSTALL_NAME}.app/Contents/Info.plist"
+echo "==> Installed: /Applications/${INSTALL_NAME}.app"
 
 echo "Done."


### PR DESCRIPTION
## Summary
- Update vendored GhosttyKit from 9771aaa (Mar 1) to v1.3.1 (332b2ae) - 307 commits
- Fix breaking change: `read_clipboard_cb` return type changed from `void` to `bool`
- Local dev builds now install as `Macuake_dev.app` to avoid conflicting with brew

Key upstream fixes included:
- use-after-free in Surface.setSelection
- memory leak of TerminalController
- suppress control-char input while composing (IME)
- Korean IME committed text handling
- search bar Enter key blocking IME composition
- render_thread stuck after dragging surface

New API: `GHOSTTY_ACTION_SET_TAB_TITLE` (can be adopted later).

## Test plan
- [ ] Build succeeds with updated xcframework
- [ ] Clipboard paste works (callback signature change)
- [ ] `build-install.sh` installs as Macuake_dev.app
- [ ] Basic terminal functionality (typing, tabs, splits)