### PR TITLE
Fix tab rename, monitor positioning, settings toggle

### DIFF
--- a/MaQuake/Sources/MaQuake/API/ControlServer.swift
+++ b/MaQuake/Sources/MaQuake/API/ControlServer.swift
@@ -198,41 +198,54 @@ final class ControlServer {
         case "control-char":  return handleControlChar(json, wc)
         case "clear":         return handleClear(json, wc)
         case "split":         return handleSplit(json, wc)
+        case "resize-split":  return handleResizeSplit(json, wc)
         case "set-appearance": return handleSetAppearance(json, wc)
         default:              return jsonError("unknown action: \(action)")
         }
     }
 
-    // MARK: - Handlers
+    // MARK: - Handlers (iTerm2-style: session = pane, tab = container)
 
     @MainActor
     private func handleList(_ wc: WindowController, includePanes: Bool = false) -> String {
+        var allSessions: [[String: Any]] = []
         let tabs = wc.tabManager.tabs.enumerated().map { (i, tab) -> [String: Any] in
             var info: [String: Any] = [
-                "session_id": tab.id.uuidString,
+                "tab_id": tab.id,
                 "index": i,
-                "title": tab.title,
+                "title": tab.displayTitle,
                 "active": i == wc.tabManager.activeTabIndex,
-                "cwd": tab.instance?.currentDirectory ?? ""
             ]
-            if includePanes, let pm = tab.paneManager {
-                info["panes"] = serializePaneTree(pm.rootPane)
-                info["focused_pane_id"] = pm.focusedPaneID.uuidString
-                info["pane_count"] = pm.rootPane.leafIDs.count
+            if let pm = tab.paneManager {
+                let sessions = pm.rootPane.leafIDs.map { sid -> [String: Any] in
+                    let inst = pm.instance(for: sid)
+                    return [
+                        "session_id": sid,
+                        "focused": sid == pm.focusedPaneID,
+                        "cwd": inst?.currentDirectory ?? ""
+                    ]
+                }
+                info["sessions"] = sessions
+                allSessions.append(contentsOf: sessions)
+                if includePanes {
+                    info["panes"] = serializePaneTree(pm.rootPane)
+                }
             }
             return info
         }
-        return jsonOK(["tabs": tabs, "count": tabs.count])
+        let activeSID = wc.tabManager.activeTab?.paneManager?.focusedPaneID ?? ""
+        return jsonOK(["tabs": tabs, "tab_count": tabs.count, "session_count": allSessions.count, "active_session_id": activeSID])
     }
 
     @MainActor
     private func handleState(_ wc: WindowController) -> String {
+        let activeSID = wc.tabManager.activeTab?.paneManager?.focusedPaneID ?? ""
         let data: [String: Any] = [
             "visible": wc.state == .visible,
             "pinned": wc.isPinned,
             "tab_count": wc.tabManager.tabs.count,
             "active_tab_index": wc.tabManager.activeTabIndex,
-            "active_session_id": wc.tabManager.activeTab?.id.uuidString ?? "",
+            "active_session_id": activeSID,
             "width_percent": wc.widthPercent,
             "height_percent": wc.heightPercent
         ]
@@ -247,68 +260,80 @@ final class ControlServer {
         if let name = json["name"] as? String, !name.isEmpty {
             wc.tabManager.renameTab(id: tab.id, name: name)
         }
-        return jsonOK(["session_id": tab.id.uuidString])
+        let sid = tab.paneManager?.focusedPaneID ?? ""
+        return jsonOK(["session_id": sid, "tab_id": tab.id])
     }
 
     @MainActor
     private func handleFocus(_ json: [String: Any], _ wc: WindowController) -> String {
-        // Focus a pane within a tab
-        if let paneID = json["pane-id"] as? String, let uuid = UUID(uuidString: paneID) {
-            let tab = resolveTab(json, wc) ?? wc.tabManager.activeTab
-            guard let tab, let pm = tab.paneManager else {
-                return jsonError("no active terminal tab")
+        // Focus a session (pane) — auto-switches to its tab
+        if let sid = json["session_id"] as? String {
+            guard let (_, tab, pm) = findSession(sid, wc) else {
+                return jsonError("session not found: \(sid)")
             }
-            guard pm.rootPane.leafIDs.contains(uuid) else {
-                return jsonError("pane not found: \(paneID)")
-            }
-            pm.focusedPaneID = uuid
-            return jsonOK(["session_id": tab.id.uuidString, "pane_id": uuid.uuidString])
+            pm.focusedPaneID = sid
+            let idx = wc.tabManager.tabs.firstIndex(where: { $0.id == tab.id })!
+            wc.tabManager.selectTab(at: idx)
+            wc.tabManager.focusTerminalInActiveTab()
+            return jsonOK(["session_id": sid])
         }
-        // Focus a tab
-        if let sessionID = json["session_id"] as? String {
-            guard let idx = wc.tabManager.tabs.firstIndex(where: { $0.id.uuidString == sessionID }) else {
-                return jsonError("session not found: \(sessionID)")
+        // Focus a tab by tab_id
+        if let tabID = json["tab_id"] as? String {
+            guard let idx = wc.tabManager.tabs.firstIndex(where: { $0.id == tabID }) else {
+                return jsonError("tab not found: \(tabID)")
             }
             wc.tabManager.selectTab(at: idx)
-            return jsonOK()
+            let sid = wc.tabManager.tabs[idx].paneManager?.focusedPaneID ?? ""
+            return jsonOK(["session_id": sid])
         }
+        // Focus by index
         if let index = json["index"] as? Int {
             wc.tabManager.selectTab(at: index)
-            return jsonOK()
+            let sid = wc.tabManager.activeTab?.paneManager?.focusedPaneID ?? ""
+            return jsonOK(["session_id": sid])
         }
         // Pane navigation by direction
         if let direction = json["direction"] as? String {
+            guard direction == "prev" || direction == "next" else {
+                return jsonError("direction must be \"prev\" or \"next\"")
+            }
             guard let tab = wc.tabManager.activeTab, let pm = tab.paneManager else {
                 return jsonError("no active terminal tab")
             }
             pm.moveFocus(direction == "prev" ? .previous : .next)
-            return jsonOK(["session_id": tab.id.uuidString, "pane_id": pm.focusedPaneID.uuidString])
+            wc.tabManager.focusTerminalInActiveTab()
+            return jsonOK(["session_id": pm.focusedPaneID])
         }
-        return jsonError("provide session_id, index, pane-id, or direction")
+        return jsonError("provide session_id, tab_id, index, or direction")
     }
 
     @MainActor
     private func handleClose(_ json: [String: Any], _ wc: WindowController) -> String {
-        // Close a specific pane
-        if let paneID = json["pane-id"] as? String, let uuid = UUID(uuidString: paneID) {
-            let tab = resolveTab(json, wc) ?? wc.tabManager.activeTab
-            guard let tab, let pm = tab.paneManager else {
-                return jsonError("no active terminal tab")
-            }
-            pm.closePane(id: uuid)
-            return jsonOK(["session_id": tab.id.uuidString, "pane_count": pm.rootPane.leafIDs.count])
-        }
-        // Close a tab
-        let sessionID = json["session_id"] as? String
-        if let sid = sessionID {
-            guard let tab = wc.tabManager.tabs.first(where: { $0.id.uuidString == sid }) else {
+        // Close a session (pane) — if last pane, closes the tab
+        if let sid = json["session_id"] as? String {
+            guard let (_, tab, pm) = findSession(sid, wc) else {
                 return jsonError("session not found: \(sid)")
             }
-            wc.tabManager.closeTab(id: tab.id)
-        } else {
-            if let tab = wc.tabManager.activeTab {
-                wc.tabManager.closeTab(id: tab.id)
+            let wasLastPane = pm.rootPane.leafCount == 1
+            pm.closePane(id: sid)
+            if wasLastPane {
+                // onLastPaneClosed fires closeTab; report 0 remaining
+                return jsonOK(["pane_count": 0])
             }
+            return jsonOK(["pane_count": pm.rootPane.leafIDs.count])
+        }
+        // Close a tab by tab_id
+        if let tabID = json["tab_id"] as? String {
+            guard wc.tabManager.tabs.contains(where: { $0.id == tabID }) else {
+                return jsonError("tab not found: \(tabID)")
+            }
+            wc.tabManager.closeTab(id: tabID)
+            return jsonOK()
+        }
+        // Close focused pane in active tab
+        if let tab = wc.tabManager.activeTab, let pm = tab.paneManager {
+            pm.closePane(id: pm.focusedPaneID)
+            return jsonOK(["pane_count": pm.rootPane.leafIDs.count])
         }
         return jsonOK()
     }
@@ -318,32 +343,28 @@ final class ControlServer {
         guard let command = json["command"] as? String else {
             return jsonError("missing command")
         }
-        let tab = resolveTab(json, wc)
-        guard let tab else { return jsonError("session not found") }
-        guard let instance = tab.instance else { return jsonError("not a terminal tab") }
+        guard let (instance, _, sessionID) = resolveSession(json, wc) else {
+            return jsonError("session not found")
+        }
 
-        // Send command as paste text, then press Enter as a key event.
-        // ghostty_surface_text triggers bracketed paste mode — the shell
-        // won't execute until Enter is pressed outside the paste brackets.
         instance.backend.send(text: command)
         if let gb = instance.backend as? GhosttyBackend {
-            // keyCode 36 = Return key, text "\r"
             gb.sendKeyPress(keyCode: 36, text: "\r")
         }
-        return jsonOK(["session_id": tab.id.uuidString])
+        return jsonOK(["session_id": sessionID])
     }
 
     @MainActor
     private func handleRead(_ json: [String: Any], _ wc: WindowController) -> String {
-        let tab = resolveTab(json, wc)
-        guard let tab else { return jsonError("session not found") }
-        guard let instance = tab.instance else { return jsonError("not a terminal tab") }
+        guard let (instance, _, sessionID) = resolveSession(json, wc) else {
+            return jsonError("session not found")
+        }
 
         let lineCount = min(max(json["lines"] as? Int ?? 20, 1), 10000)
         let snapshot = instance.backend.readBuffer(lineCount: lineCount)
 
         return jsonOK([
-            "session_id": tab.id.uuidString,
+            "session_id": sessionID,
             "lines": snapshot.lines,
             "rows": snapshot.rows,
             "cols": snapshot.cols
@@ -355,12 +376,12 @@ final class ControlServer {
         guard let text = json["text"] as? String else {
             return jsonError("missing text")
         }
-        let tab = resolveTab(json, wc)
-        guard let tab else { return jsonError("session not found") }
-        guard let instance = tab.instance else { return jsonError("not a terminal tab") }
+        guard let (instance, _, sessionID) = resolveSession(json, wc) else {
+            return jsonError("session not found")
+        }
 
         instance.backend.send(text: text)
-        return jsonOK(["session_id": tab.id.uuidString])
+        return jsonOK(["session_id": sessionID])
     }
 
     @MainActor
@@ -368,14 +389,13 @@ final class ControlServer {
         guard let key = json["key"] as? String else {
             return jsonError("missing key")
         }
-        let tab = resolveTab(json, wc)
-        guard let tab else { return jsonError("session not found") }
-        guard let instance = tab.instance else { return jsonError("not a terminal tab") }
+        guard let (instance, _, sessionID) = resolveSession(json, wc) else {
+            return jsonError("session not found")
+        }
 
         guard let gb = instance.backend as? GhosttyBackend else {
             return jsonError("backend does not support key events")
         }
-        // Send as key events, not paste — control chars must bypass bracketed paste
         switch key {
         case "c":     gb.sendKeyPress(keyCode: 8,  text: "\u{03}")
         case "d":     gb.sendKeyPress(keyCode: 2,  text: "\u{04}")
@@ -391,18 +411,18 @@ final class ControlServer {
         case "tab":   gb.sendKeyPress(keyCode: 48, text: "\t")
         default:      return jsonError("unknown key: \(key)")
         }
-        return jsonOK(["session_id": tab.id.uuidString])
+        return jsonOK(["session_id": sessionID])
     }
 
     @MainActor
     private func handleClear(_ json: [String: Any], _ wc: WindowController) -> String {
-        let tab = resolveTab(json, wc)
-        guard let tab else { return jsonError("session not found") }
-        guard let instance = tab.instance else { return jsonError("not a terminal tab") }
+        guard let (instance, _, sessionID) = resolveSession(json, wc) else {
+            return jsonError("session not found")
+        }
         if let gb = instance.backend as? GhosttyBackend {
             gb.sendKeyPress(keyCode: 37, text: "\u{0C}")
         }
-        return jsonOK(["session_id": tab.id.uuidString])
+        return jsonOK(["session_id": sessionID])
     }
 
     @MainActor
@@ -411,20 +431,71 @@ final class ControlServer {
               direction == "h" || direction == "v" else {
             return jsonError("provide direction: \"h\" or \"v\"")
         }
-        guard let tab = resolveTab(json, wc) ?? wc.tabManager.activeTab,
-              let pm = tab.paneManager else {
+
+        let axis: Axis = direction == "h" ? .horizontal : .vertical
+        let ratio = CGFloat(json["ratio"] as? Double ?? 0.5)
+
+        // Split a specific session, or the focused pane in active tab
+        if let sid = json["session_id"] as? String {
+            guard let (_, _, pm) = findSession(sid, wc) else {
+                return jsonError("session not found: \(sid)")
+            }
+            guard pm.splitPane(id: sid, axis: axis, ratio: ratio) else {
+                return jsonError("split failed")
+            }
+            return jsonOK(["session_id": pm.focusedPaneID])
+        }
+
+        guard let tab = wc.tabManager.activeTab, let pm = tab.paneManager else {
             return jsonError("no active terminal tab")
         }
-        let axis: Axis = direction == "h" ? .horizontal : .vertical
-        pm.splitFocusedPane(axis: axis)
-        return jsonOK(["session_id": tab.id.uuidString])
+        guard pm.splitFocusedPane(axis: axis, ratio: ratio) else {
+            return jsonError("split failed")
+        }
+        return jsonOK(["session_id": pm.focusedPaneID])
+    }
+
+    @MainActor
+    private func handleResizeSplit(_ json: [String: Any], _ wc: WindowController) -> String {
+        guard let tab = wc.tabManager.activeTab, let pm = tab.paneManager else {
+            return jsonError("no active terminal tab")
+        }
+
+        // Option 1: Set absolute ratio
+        if let ratio = json["ratio"] as? Double {
+            let targetPaneID = json["session_id"] as? String ?? pm.focusedPaneID
+            guard let splitID = parentSplitID(of: targetPaneID, in: pm.rootPane) else {
+                return jsonError("pane is not in a split")
+            }
+            pm.updateSplitRatio(splitID: splitID, ratio: CGFloat(ratio))
+            return jsonOK()
+        }
+
+        // Option 2: Equalize all splits
+        if let equalize = json["equalize"] as? Bool, equalize {
+            pm.equalizeSplits()
+            return jsonOK()
+        }
+
+        // Option 3: Resize by delta (percentage points, e.g. 10 = +10%)
+        if let delta = json["delta"] as? Double {
+            let targetPaneID = json["session_id"] as? String ?? pm.focusedPaneID
+            // Temporarily set focus to target pane for directional resize
+            let originalFocus = pm.focusedPaneID
+            pm.focusedPaneID = targetPaneID
+            pm.resizeFocusedSplit(delta: CGFloat(delta) / 100.0)
+            pm.focusedPaneID = originalFocus
+            return jsonOK()
+        }
+
+        return jsonError("provide ratio (0.1-0.9), delta (-90 to 90), or equalize: true")
     }
 
     @MainActor
     private func serializePaneTree(_ node: PaneNode) -> [String: Any] {
         switch node {
         case .leaf(let id, _):
-            return ["type": "leaf", "pane_id": id.uuidString]
+            return ["type": "leaf", "session_id": id]
         case .split(_, let axis, let first, let second, let ratio):
             return [
                 "type": "split",
@@ -438,24 +509,58 @@ final class ControlServer {
 
     @MainActor
     private func handleSetAppearance(_ json: [String: Any], _ wc: WindowController) -> String {
-        if let title = json["title"] as? String {
-            if let tab = resolveTab(json, wc) {
-                wc.tabManager.renameTab(id: tab.id, name: title.isEmpty ? nil : title)
-                return jsonOK(["session_id": tab.id.uuidString])
-            }
-            return jsonError("session not found")
+        guard let title = json["title"] as? String else {
+            return jsonError("provide title")
         }
-        return jsonError("provide title")
+        // Find tab by tab_id, or by session_id (find containing tab), or active tab
+        if let tabID = json["tab_id"] as? String {
+            guard wc.tabManager.tabs.contains(where: { $0.id == tabID }) else {
+                return jsonError("tab not found: \(tabID)")
+            }
+            wc.tabManager.renameTab(id: tabID, name: title.isEmpty ? nil : title)
+            return jsonOK(["tab_id": tabID])
+        }
+        if let sid = json["session_id"] as? String {
+            guard let (_, tab, _) = findSession(sid, wc) else {
+                return jsonError("session not found: \(sid)")
+            }
+            wc.tabManager.renameTab(id: tab.id, name: title.isEmpty ? nil : title)
+            return jsonOK(["tab_id": tab.id])
+        }
+        guard let tab = wc.tabManager.activeTab else {
+            return jsonError("no active tab")
+        }
+        wc.tabManager.renameTab(id: tab.id, name: title.isEmpty ? nil : title)
+        return jsonOK(["tab_id": tab.id])
     }
 
     // MARK: - Helpers
 
+    /// Find a session (pane) by its short ID, searching across all tabs.
     @MainActor
-    private func resolveTab(_ json: [String: Any], _ wc: WindowController) -> Tab? {
-        if let sid = json["session_id"] as? String {
-            return wc.tabManager.tabs.first(where: { $0.id.uuidString == sid })
+    private func findSession(_ sessionID: String, _ wc: WindowController) -> (TerminalInstance, Tab, PaneManager)? {
+        for tab in wc.tabManager.tabs {
+            guard let pm = tab.paneManager else { continue }
+            if pm.rootPane.leafIDs.contains(sessionID) {
+                guard let instance = pm.instance(for: sessionID) else { continue }
+                return (instance, tab, pm)
+            }
         }
-        return wc.tabManager.activeTab
+        return nil
+    }
+
+    /// Resolve a session from JSON params, defaulting to focused pane in active tab.
+    @MainActor
+    private func resolveSession(_ json: [String: Any], _ wc: WindowController) -> (TerminalInstance, Tab, String)? {
+        if let sid = json["session_id"] as? String {
+            guard let (inst, tab, _) = findSession(sid, wc) else { return nil }
+            return (inst, tab, sid)
+        }
+        // Default: focused pane in active tab
+        guard let tab = wc.tabManager.activeTab, let pm = tab.paneManager else { return nil }
+        let focusedID = pm.focusedPaneID
+        guard let inst = pm.instance(for: focusedID) else { return nil }
+        return (inst, tab, focusedID)
     }
 }
 

--- a/MaQuake/Sources/MaQuake/MCP/MCPHTTPServer.swift
+++ b/MaQuake/Sources/MaQuake/MCP/MCPHTTPServer.swift
@@ -13,6 +13,9 @@ final class MCPHTTPServer {
     private var mcpServer: Server?
     private var transport: StatelessHTTPServerTransport?
     private weak var controlServer: ControlServer?
+    private var wakeObserver: Any?
+    private var restartAttempts = 0
+    private static let maxRestartAttempts = 5
 
     nonisolated static let defaultPort: UInt16 = 19876
 
@@ -55,13 +58,42 @@ final class MCPHTTPServer {
         }
 
         startListener()
+
+        // Restart listener after system wake from sleep
+        wakeObserver = NSWorkspace.shared.notificationCenter.addObserver(
+            forName: NSWorkspace.didWakeNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            print("MCPHTTPServer: system wake — restarting listener")
+            self?.restartAttempts = 0
+            self?.restartListener()
+        }
     }
 
     func stop() {
+        if let obs = wakeObserver {
+            NSWorkspace.shared.notificationCenter.removeObserver(obs)
+            wakeObserver = nil
+        }
         listener?.cancel()
         listener = nil
         Task {
             await transport?.disconnect()
+        }
+    }
+
+    private func restartListener() {
+        guard restartAttempts < Self.maxRestartAttempts else {
+            print("MCPHTTPServer: max restart attempts (\(Self.maxRestartAttempts)) reached — giving up")
+            return
+        }
+        restartAttempts += 1
+        listener?.cancel()
+        listener = nil
+        // Delay to let the port release
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { [weak self] in
+            self?.startListener()
         }
     }
 
@@ -78,12 +110,16 @@ final class MCPHTTPServer {
         }
 
         let capturedPort = port
-        listener?.stateUpdateHandler = { state in
+        listener?.stateUpdateHandler = { [weak self] state in
             switch state {
             case .ready:
+                DispatchQueue.main.async { self?.restartAttempts = 0 }
                 print("MCPHTTPServer: listening on http://localhost:\(capturedPort)/mcp")
             case .failed(let error):
-                print("MCPHTTPServer: listener failed: \(error)")
+                print("MCPHTTPServer: listener failed: \(error) — restarting")
+                DispatchQueue.main.async {
+                    self?.restartListener()
+                }
             default:
                 break
             }
@@ -280,13 +316,13 @@ final class MCPHTTPServer {
     // MARK: - Tool definitions
 
     nonisolated static let allTools: [Tool] = [
-        Tool(name: "state", description: "Get terminal state (visible, pinned, tab count, active tab, size)",
+        Tool(name: "state", description: "Get terminal state (visible, pinned, tab count, active session)",
              inputSchema: .object(["type": .string("object"), "properties": .object([:])]) ),
-        Tool(name: "list", description: "List all terminal tabs with session IDs, titles, working directories. Set include_panes=true to get pane tree.",
+        Tool(name: "list", description: "List tabs and sessions (panes). Each session has an 8-char session_id.",
              inputSchema: .object([
                 "type": .string("object"),
                 "properties": .object([
-                    "include_panes": .object(["type": .string("boolean"), "description": .string("Include pane tree structure for each tab (default: false)")])
+                    "include_panes": .object(["type": .string("boolean"), "description": .string("Include pane tree structure (default: false)")])
                 ])
              ])),
         Tool(name: "toggle", description: "Toggle terminal visibility (show/hide)",
@@ -307,81 +343,93 @@ final class MCPHTTPServer {
                     "name": .object(["type": .string("string"), "description": .string("Tab title (overrides auto-detected title)")])
                 ])
              ])),
-        Tool(name: "focus", description: "Focus a tab (by session_id/index), a pane (by pane_id), or navigate panes (direction: next/prev)",
+        Tool(name: "focus", description: "Focus a session (auto-switches tab), a tab (by tab_id/index), or navigate panes (direction: next/prev)",
              inputSchema: .object([
                 "type": .string("object"),
                 "properties": .object([
-                    "session_id": .object(["type": .string("string"), "description": .string("Tab session UUID")]),
+                    "session_id": .object(["type": .string("string"), "description": .string("Session (pane) ID — auto-switches to its tab")]),
+                    "tab_id": .object(["type": .string("string"), "description": .string("Tab container ID")]),
                     "index": .object(["type": .string("integer"), "description": .string("Tab index (0-based)")]),
-                    "pane_id": .object(["type": .string("string"), "description": .string("Pane UUID (from list with include_panes)")]),
                     "direction": .object(["type": .string("string"), "description": .string("Pane navigation: next or prev")])
                 ])
              ])),
-        Tool(name: "close_session", description: "Close a tab (by session_id) or a pane (by pane_id). Omit both to close active tab.",
+        Tool(name: "close_session", description: "Close a session (pane) or a tab. If last pane, tab closes too.",
              inputSchema: .object([
                 "type": .string("object"),
                 "properties": .object([
-                    "session_id": .object(["type": .string("string"), "description": .string("Tab session UUID")]),
-                    "pane_id": .object(["type": .string("string"), "description": .string("Pane UUID to close (closes pane, not whole tab)")])
+                    "session_id": .object(["type": .string("string"), "description": .string("Session (pane) ID to close")]),
+                    "tab_id": .object(["type": .string("string"), "description": .string("Tab ID to close (all panes)")])
                 ])
              ])),
-        Tool(name: "execute", description: "Execute a shell command in a terminal tab. Sends text and presses Enter.",
+        Tool(name: "execute", description: "Execute a shell command in a session. Sends text and presses Enter.",
              inputSchema: .object([
                 "type": .string("object"),
                 "properties": .object([
                     "command": .object(["type": .string("string"), "description": .string("Shell command to execute")]),
-                    "session_id": .object(["type": .string("string"), "description": .string("Target tab (default: active)")])
+                    "session_id": .object(["type": .string("string"), "description": .string("Target session (default: focused)")])
                 ]),
                 "required": .array([.string("command")])
              ])),
-        Tool(name: "read", description: "Read terminal output (last N lines from the screen buffer)",
+        Tool(name: "read", description: "Read terminal output from a session (last N lines)",
              inputSchema: .object([
                 "type": .string("object"),
                 "properties": .object([
-                    "session_id": .object(["type": .string("string"), "description": .string("Target tab (default: active)")]),
+                    "session_id": .object(["type": .string("string"), "description": .string("Target session (default: focused)")]),
                     "lines": .object(["type": .string("integer"), "description": .string("Number of lines to read (default: 20)")])
                 ])
              ])),
-        Tool(name: "paste", description: "Paste text into the terminal (no Enter key appended)",
+        Tool(name: "paste", description: "Paste text into a session (no Enter key appended)",
              inputSchema: .object([
                 "type": .string("object"),
                 "properties": .object([
                     "text": .object(["type": .string("string"), "description": .string("Text to paste")]),
-                    "session_id": .object(["type": .string("string"), "description": .string("Target tab (default: active)")])
+                    "session_id": .object(["type": .string("string"), "description": .string("Target session (default: focused)")])
                 ]),
                 "required": .array([.string("text")])
              ])),
-        Tool(name: "control_char", description: "Send a control character (ctrl+c, ctrl+d, enter, esc, tab, etc.)",
+        Tool(name: "control_char", description: "Send a control character to a session (ctrl+c, ctrl+d, enter, esc, tab, etc.)",
              inputSchema: .object([
                 "type": .string("object"),
                 "properties": .object([
                     "key": .object(["type": .string("string"), "description": .string("Key: c, d, z, a, e, k, l, u, w, enter, esc, tab")]),
-                    "session_id": .object(["type": .string("string"), "description": .string("Target tab (default: active)")])
+                    "session_id": .object(["type": .string("string"), "description": .string("Target session (default: focused)")])
                 ]),
                 "required": .array([.string("key")])
              ])),
-        Tool(name: "clear", description: "Clear the terminal screen (sends Ctrl+L)",
+        Tool(name: "clear", description: "Clear a session screen (sends Ctrl+L)",
              inputSchema: .object([
                 "type": .string("object"),
                 "properties": .object([
-                    "session_id": .object(["type": .string("string"), "description": .string("Target tab (default: active)")])
+                    "session_id": .object(["type": .string("string"), "description": .string("Target session (default: focused)")])
                 ])
              ])),
-        Tool(name: "split", description: "Split the focused pane horizontally or vertically",
+        Tool(name: "split", description: "Split a session horizontally or vertically. Returns new session_id.",
              inputSchema: .object([
                 "type": .string("object"),
                 "properties": .object([
                     "direction": .object(["type": .string("string"), "description": .string("Split direction: h (horizontal) or v (vertical)")]),
-                    "session_id": .object(["type": .string("string"), "description": .string("Target tab (default: active)")])
+                    "session_id": .object(["type": .string("string"), "description": .string("Session to split (default: focused)")]),
+                    "ratio": .object(["type": .string("number"), "description": .string("Split ratio 0.1-0.9 for first pane (default: 0.5)")])
                 ]),
                 "required": .array([.string("direction")])
              ])),
-        Tool(name: "set_appearance", description: "Set tab title",
+        Tool(name: "resize_split", description: "Resize a split pane. Set absolute ratio, delta, or equalize all splits.",
+             inputSchema: .object([
+                "type": .string("object"),
+                "properties": .object([
+                    "ratio": .object(["type": .string("number"), "description": .string("Absolute ratio 0.1-0.9 for parent split")]),
+                    "delta": .object(["type": .string("number"), "description": .string("Resize by delta percentage points (e.g. 10 = grow 10%)")]),
+                    "equalize": .object(["type": .string("boolean"), "description": .string("Set all splits to equal ratio")]),
+                    "session_id": .object(["type": .string("string"), "description": .string("Target session (default: focused)")])
+                ])
+             ])),
+        Tool(name: "set_appearance", description: "Set tab title (by tab_id, session_id, or active tab)",
              inputSchema: .object([
                 "type": .string("object"),
                 "properties": .object([
                     "title": .object(["type": .string("string"), "description": .string("New tab title (empty to reset)")]),
-                    "session_id": .object(["type": .string("string"), "description": .string("Target tab (default: active)")])
+                    "tab_id": .object(["type": .string("string"), "description": .string("Tab ID")]),
+                    "session_id": .object(["type": .string("string"), "description": .string("Session ID (resolves to its tab)")])
                 ]),
                 "required": .array([.string("title")])
              ])),
@@ -432,19 +480,19 @@ final class MCPHTTPServer {
             "new_tab": "new-tab", "focus": "focus", "close_session": "close-session",
             "execute": "execute", "read": "read", "paste": "paste",
             "control_char": "control-char", "clear": "clear", "split": "split",
-            "set_appearance": "set-appearance",
+            "resize_split": "resize-split", "set_appearance": "set-appearance",
         ]
 
         guard let action = actionMap[params.name] else {
             throw MCPError.invalidParams("Unknown tool: \(params.name)")
         }
 
-        // Map MCP argument names to ControlServer JSON keys.
-        // Most use underscore→dash, but session_id stays as-is (ControlServer expects underscore).
+        // Map MCP argument names (snake_case) to ControlServer JSON keys.
         let keyMap: [String: String] = [
             "include_panes": "include-panes",
-            "pane_id": "pane-id",
             "session_id": "session_id",
+            "tab_id": "tab_id",
+            "close_session": "close-session",
         ]
 
         var request: [String: Any] = ["action": action]

--- a/MaQuake/Sources/MaQuake/Panes/PaneManager.swift
+++ b/MaQuake/Sources/MaQuake/Panes/PaneManager.swift
@@ -1,11 +1,10 @@
 import Foundation
 import SwiftUI
-import GhosttyKit
 import os.log
 
 final class PaneManager: ObservableObject {
     @Published var rootPane: PaneNode
-    @Published var focusedPaneID: UUID
+    @Published var focusedPaneID: String
 
     /// Called when the focused pane's title changes.
     var onFocusedTitleChange: ((String) -> Void)?
@@ -16,7 +15,7 @@ final class PaneManager: ObservableObject {
 
     init(directory: String? = nil) {
         let instance = TerminalInstance()
-        let id = UUID()
+        let id = generateShortID()
         self.rootPane = .leaf(id: id, backend: instance.backend)
         self.focusedPaneID = id
         setupCallbacks(for: id, instance: instance)
@@ -26,10 +25,14 @@ final class PaneManager: ObservableObject {
     }
 
     /// Tracks TerminalInstance per pane for lifecycle (title, directory, process exit)
-    private var instances: [UUID: TerminalInstance] = [:]
+    private var instances: [String: TerminalInstance] = [:]
 
     var focusedInstance: TerminalInstance? {
         instances[focusedPaneID]
+    }
+
+    func instance(for paneID: String) -> TerminalInstance? {
+        instances[paneID]
     }
 
     var focusedBackend: TerminalBackend? {
@@ -43,32 +46,32 @@ final class PaneManager: ObservableObject {
     // MARK: - Split (native Ghostty surfaces)
 
     @discardableResult
-    func splitPane(id: UUID, axis: Axis) -> Bool {
-        guard let sourceBackend = rootPane.backend(for: id) as? GhosttyBackend,
-              let newBackend = sourceBackend.createSplitSurface() else {
+    func splitPane(id: String, axis: Axis, ratio: CGFloat = 0.5) -> Bool {
+        guard let sourceBackend = rootPane.backend(for: id),
+              let newBackend = sourceBackend.createSplitBackend() else {
             os_log(.error, "Failed to create split surface")
             return false
         }
         let newInstance = TerminalInstance(existingBackend: newBackend)
 
-        let newPaneID = UUID()
+        let newPaneID = generateShortID()
         instances[newPaneID] = newInstance
         setupCallbacks(for: newPaneID, instance: newInstance)
 
-        rootPane = splitNode(rootPane, targetID: id, axis: axis, newBackend: newBackend, newPaneID: newPaneID)
+        rootPane = splitNode(rootPane, targetID: id, axis: axis, newBackend: newBackend, newPaneID: newPaneID, ratio: ratio)
         focusedPaneID = newPaneID
         return true
     }
 
     @discardableResult
-    func splitFocusedPane(axis: Axis) -> Bool {
-        splitPane(id: focusedPaneID, axis: axis)
+    func splitFocusedPane(axis: Axis, ratio: CGFloat = 0.5) -> Bool {
+        splitPane(id: focusedPaneID, axis: axis, ratio: ratio)
     }
 
     // MARK: - Close
 
     @discardableResult
-    func closePane(id: UUID) -> Bool {
+    func closePane(id: String) -> Bool {
         if case .leaf(let leafID, let backend) = rootPane, leafID == id {
             backend.terminate()
             instances.removeValue(forKey: id)
@@ -85,6 +88,40 @@ final class PaneManager: ObservableObject {
             return true
         }
         return true
+    }
+
+    // MARK: - Resize
+
+    /// Update the ratio of a specific split node.
+    func updateSplitRatio(splitID: String, ratio: CGFloat) {
+        rootPane = updateRatio(rootPane, splitID: splitID, ratio: ratio)
+    }
+
+    /// Resize the split containing the focused pane by a delta amount.
+    /// Positive delta increases the focused pane's share.
+    func resizeFocusedSplit(delta: CGFloat) {
+        guard let splitID = parentSplitID(of: focusedPaneID, in: rootPane) else { return }
+        if case .split(_, _, let first, _, let ratio) = findSplit(splitID, in: rootPane) ?? rootPane {
+            let isInFirst = first.leafIDs.contains(focusedPaneID)
+            let newRatio = isInFirst ? ratio + delta : ratio - delta
+            rootPane = updateRatio(rootPane, splitID: splitID, ratio: newRatio)
+        }
+    }
+
+    /// Set all split ratios to 0.5 (equalize).
+    func equalizeSplits() {
+        rootPane = equalizeRatios(rootPane)
+    }
+
+    /// Find a split node by ID.
+    private func findSplit(_ splitID: String, in node: PaneNode) -> PaneNode? {
+        switch node {
+        case .leaf:
+            return nil
+        case .split(let id, _, let first, let second, _):
+            if id == splitID { return node }
+            return findSplit(splitID, in: first) ?? findSplit(splitID, in: second)
+        }
     }
 
     // MARK: - Navigation
@@ -106,7 +143,7 @@ final class PaneManager: ObservableObject {
 
     // MARK: - Callbacks
 
-    private func setupCallbacks(for paneID: UUID, instance: TerminalInstance) {
+    private func setupCallbacks(for paneID: String, instance: TerminalInstance) {
         instance.onTitleChange = { [weak self] title in
             Task { @MainActor in
                 guard let self else { return }
@@ -129,6 +166,20 @@ final class PaneManager: ObservableObject {
             Task { @MainActor in
                 guard let self else { return }
                 self.closePane(id: paneID)
+            }
+        }
+
+        instance.onResizeSplit = { [weak self] delta in
+            Task { @MainActor in
+                guard let self else { return }
+                self.resizeFocusedSplit(delta: delta)
+            }
+        }
+
+        instance.onEqualizeSplits = { [weak self] in
+            Task { @MainActor in
+                guard let self else { return }
+                self.equalizeSplits()
             }
         }
     }

--- a/MaQuake/Sources/MaQuake/Panes/PaneNode.swift
+++ b/MaQuake/Sources/MaQuake/Panes/PaneNode.swift
@@ -1,12 +1,17 @@
 import Foundation
 import SwiftUI
 
+/// Generate a random 8-character hex ID (e.g. "A3F1B2C4").
+func generateShortID() -> String {
+    String(UUID().uuidString.prefix(8))
+}
+
 /// A binary tree node representing either a single terminal pane or a split.
 indirect enum PaneNode: Identifiable {
-    case leaf(id: UUID, backend: TerminalBackend)
-    case split(id: UUID, axis: Axis, first: PaneNode, second: PaneNode, ratio: CGFloat)
+    case leaf(id: String, backend: TerminalBackend)
+    case split(id: String, axis: Axis, first: PaneNode, second: PaneNode, ratio: CGFloat)
 
-    var id: UUID {
+    var id: String {
         switch self {
         case .leaf(let id, _): return id
         case .split(let id, _, _, _, _): return id
@@ -14,7 +19,7 @@ indirect enum PaneNode: Identifiable {
     }
 
     /// All leaf pane IDs in order (left-to-right / top-to-bottom).
-    var leafIDs: [UUID] {
+    var leafIDs: [String] {
         switch self {
         case .leaf(let id, _):
             return [id]
@@ -24,7 +29,7 @@ indirect enum PaneNode: Identifiable {
     }
 
     /// Find the backend for a given pane ID.
-    func backend(for paneID: UUID) -> TerminalBackend? {
+    func backend(for paneID: String) -> TerminalBackend? {
         switch self {
         case .leaf(let id, let b):
             return id == paneID ? b : nil
@@ -57,30 +62,76 @@ indirect enum PaneNode: Identifiable {
 // MARK: - Tree operations (pure functions returning new trees)
 
 /// Insert a new pane next to the target leaf, splitting it along the given axis.
-func splitNode(_ node: PaneNode, targetID: UUID, axis: Axis, newBackend: TerminalBackend, newPaneID: UUID) -> PaneNode {
+func splitNode(_ node: PaneNode, targetID: String, axis: Axis, newBackend: TerminalBackend, newPaneID: String, ratio: CGFloat = 0.5) -> PaneNode {
     switch node {
     case .leaf(let id, _) where id == targetID:
         return .split(
-            id: UUID(),
+            id: generateShortID(),
             axis: axis,
             first: node,
             second: .leaf(id: newPaneID, backend: newBackend),
-            ratio: 0.5
+            ratio: ratio
         )
     case .leaf:
         return node
-    case .split(let id, let ax, let first, let second, let ratio):
-        let newFirst = splitNode(first, targetID: targetID, axis: axis, newBackend: newBackend, newPaneID: newPaneID)
+    case .split(let id, let ax, let first, let second, let r):
+        let newFirst = splitNode(first, targetID: targetID, axis: axis, newBackend: newBackend, newPaneID: newPaneID, ratio: ratio)
         if newFirst.id != first.id {
-            return .split(id: id, axis: ax, first: newFirst, second: second, ratio: ratio)
+            return .split(id: id, axis: ax, first: newFirst, second: second, ratio: r)
         }
-        let newSecond = splitNode(second, targetID: targetID, axis: axis, newBackend: newBackend, newPaneID: newPaneID)
-        return .split(id: id, axis: ax, first: first, second: newSecond, ratio: ratio)
+        let newSecond = splitNode(second, targetID: targetID, axis: axis, newBackend: newBackend, newPaneID: newPaneID, ratio: ratio)
+        return .split(id: id, axis: ax, first: first, second: newSecond, ratio: r)
+    }
+}
+
+/// Update the ratio of a split node identified by its ID.
+func updateRatio(_ node: PaneNode, splitID: String, ratio: CGFloat) -> PaneNode {
+    let clamped = min(max(ratio, 0.1), 0.9)
+    switch node {
+    case .leaf:
+        return node
+    case .split(let id, let axis, let first, let second, let r):
+        if id == splitID {
+            return .split(id: id, axis: axis, first: first, second: second, ratio: clamped)
+        }
+        let newFirst = updateRatio(first, splitID: splitID, ratio: ratio)
+        let newSecond = updateRatio(second, splitID: splitID, ratio: ratio)
+        return .split(id: id, axis: axis, first: newFirst, second: newSecond, ratio: r)
+    }
+}
+
+/// Find the parent split ID for a given leaf pane.
+func parentSplitID(of paneID: String, in node: PaneNode) -> String? {
+    switch node {
+    case .leaf:
+        return nil
+    case .split(let id, _, let first, let second, _):
+        if first.leafIDs.contains(paneID) || second.leafIDs.contains(paneID) {
+            // Check if the pane is a direct child leaf
+            if case .leaf(let lid, _) = first, lid == paneID { return id }
+            if case .leaf(let lid, _) = second, lid == paneID { return id }
+            // Otherwise recurse into the child that contains it
+            return parentSplitID(of: paneID, in: first) ?? parentSplitID(of: paneID, in: second)
+        }
+        return nil
+    }
+}
+
+/// Set all split ratios in the tree to 0.5 (equal).
+func equalizeRatios(_ node: PaneNode) -> PaneNode {
+    switch node {
+    case .leaf:
+        return node
+    case .split(let id, let axis, let first, let second, _):
+        return .split(id: id, axis: axis,
+                      first: equalizeRatios(first),
+                      second: equalizeRatios(second),
+                      ratio: 0.5)
     }
 }
 
 /// Remove a leaf node and collapse its parent split.
-func removeNode(_ node: PaneNode, targetID: UUID) -> PaneNode? {
+func removeNode(_ node: PaneNode, targetID: String) -> PaneNode? {
     switch node {
     case .leaf(let id, let backend) where id == targetID:
         backend.terminate()

--- a/MaQuake/Sources/MaQuake/Panes/PaneSplitView.swift
+++ b/MaQuake/Sources/MaQuake/Panes/PaneSplitView.swift
@@ -28,6 +28,9 @@ struct PaneSplitView: View {
         explicitNode ?? paneManager.rootPane
     }
 
+    /// Minimum pane size in points.
+    private let minPaneSize: CGFloat = 40
+
     var body: some View {
         switch node {
         case .leaf(let id, let backend):
@@ -70,31 +73,91 @@ struct PaneSplitView: View {
                 }
             }
 
-        case .split(_, let axis, let first, let second, let ratio):
+        case .split(let splitID, let axis, let first, let second, let ratio):
             GeometryReader { geo in
                 if axis == .horizontal {
+                    let firstWidth = (geo.size.width - 1) * ratio
                     HStack(spacing: 0) {
                         PaneSplitView(node: first, paneManager: paneManager, tabManager: tabManager, theme: theme)
-                            .frame(width: (geo.size.width - 1) * ratio)
+                            .frame(width: firstWidth)
 
-                        Rectangle()
-                            .fill(Color.gray.opacity(0.4))
-                            .frame(width: 1)
+                        SplitDivider(axis: .horizontal)
+                            .gesture(DragGesture()
+                                .onChanged { value in
+                                    let newRatio = value.location.x / geo.size.width
+                                    let clamped = min(max(newRatio, minPaneSize / geo.size.width), 1 - minPaneSize / geo.size.width)
+                                    paneManager.updateSplitRatio(splitID: splitID, ratio: clamped)
+                                }
+                            )
+                            .onTapGesture(count: 2) {
+                                paneManager.updateSplitRatio(splitID: splitID, ratio: 0.5)
+                            }
 
                         PaneSplitView(node: second, paneManager: paneManager, tabManager: tabManager, theme: theme)
                     }
                 } else {
+                    let firstHeight = (geo.size.height - 1) * ratio
                     VStack(spacing: 0) {
                         PaneSplitView(node: first, paneManager: paneManager, tabManager: tabManager, theme: theme)
-                            .frame(height: (geo.size.height - 1) * ratio)
+                            .frame(height: firstHeight)
 
-                        Rectangle()
-                            .fill(Color.gray.opacity(0.4))
-                            .frame(height: 1)
+                        SplitDivider(axis: .vertical)
+                            .gesture(DragGesture()
+                                .onChanged { value in
+                                    let newRatio = value.location.y / geo.size.height
+                                    let clamped = min(max(newRatio, minPaneSize / geo.size.height), 1 - minPaneSize / geo.size.height)
+                                    paneManager.updateSplitRatio(splitID: splitID, ratio: clamped)
+                                }
+                            )
+                            .onTapGesture(count: 2) {
+                                paneManager.updateSplitRatio(splitID: splitID, ratio: 0.5)
+                            }
 
                         PaneSplitView(node: second, paneManager: paneManager, tabManager: tabManager, theme: theme)
                     }
                 }
+            }
+        }
+    }
+}
+
+/// Draggable divider between split panes.
+/// Visible line is 1pt, but hit target is 7pt wide for easy grabbing.
+private struct SplitDivider: View {
+    let axis: Axis
+
+    var body: some View {
+        ZStack {
+            // Invisible hit target
+            Rectangle()
+                .fill(Color.clear)
+                .frame(
+                    width: axis == .horizontal ? 7 : nil,
+                    height: axis == .vertical ? 7 : nil
+                )
+                .contentShape(Rectangle())
+
+            // Visible divider line
+            Rectangle()
+                .fill(Color.gray.opacity(0.4))
+                .frame(
+                    width: axis == .horizontal ? 1 : nil,
+                    height: axis == .vertical ? 1 : nil
+                )
+        }
+        .frame(
+            width: axis == .horizontal ? 7 : nil,
+            height: axis == .vertical ? 7 : nil
+        )
+        .onHover { hovering in
+            if hovering {
+                if axis == .horizontal {
+                    NSCursor.resizeLeftRight.push()
+                } else {
+                    NSCursor.resizeUpDown.push()
+                }
+            } else {
+                NSCursor.pop()
             }
         }
     }

--- a/MaQuake/Sources/MaQuake/Tabs/TabBarView.swift
+++ b/MaQuake/Sources/MaQuake/Tabs/TabBarView.swift
@@ -335,6 +335,10 @@ final class DoubleClickNSView: NSView {
                         if v is MouseDownNSView || v is NSButton || v is NSTextField {
                             return event
                         }
+                        let className = String(describing: type(of: v))
+                        if className.contains("Button") {
+                            return event
+                        }
                         if v.gestureRecognizers.contains(where: { $0 is NSClickGestureRecognizer }) {
                             return event
                         }

--- a/MaQuake/Sources/MaQuake/Tabs/TabBarView.swift
+++ b/MaQuake/Sources/MaQuake/Tabs/TabBarView.swift
@@ -6,7 +6,7 @@ struct TabBarView: View {
     @ObservedObject var windowController: WindowController
     @State private var showTabList = false
     @State private var tabsOverflow = false
-    @State private var draggedTabID: UUID?
+    @State private var draggedTabID: String?
 
     var body: some View {
         HStack(spacing: 0) {
@@ -16,11 +16,18 @@ struct TabBarView: View {
                         HStack(spacing: 1) {
                             ForEach(Array(tabManager.tabs.enumerated()), id: \.element.id) { index, tab in
                                 TabItemView(
+                                    tabID: tab.id,
                                     index: index + 1,
                                     title: shortTitle(tab.displayTitle),
                                     kind: tab.kind,
                                     isActive: index == tabManager.activeTabIndex,
                                     hasCustomTitle: tab.customTitle != nil,
+                                    isEditing: Binding(
+                                        get: { tabManager.editingTabID == tab.id },
+                                        set: { editing in
+                                            tabManager.editingTabID = editing ? tab.id : nil
+                                        }
+                                    ),
                                     onSelect: {
                                         tabManager.selectTab(at: index)
                                     },
@@ -35,7 +42,7 @@ struct TabBarView: View {
                                 .opacity(draggedTabID == tab.id ? 0.4 : 1.0)
                                 .onDrag {
                                     draggedTabID = tab.id
-                                    return NSItemProvider(object: tab.id.uuidString as NSString)
+                                    return NSItemProvider(object: tab.id as NSString)
                                 }
                                 .onDrop(of: [.text], delegate: TabDropDelegate(
                                     tabManager: tabManager,
@@ -140,18 +147,19 @@ func tabShortTitle(_ title: String) -> String {
 }
 
 struct TabItemView: View {
+    let tabID: String
     let index: Int
     let title: String
     let kind: Tab.TabKind
     let isActive: Bool
     let hasCustomTitle: Bool
+    @Binding var isEditing: Bool
     let onSelect: () -> Void
     let onClose: () -> Void
     let onRename: (String?) -> Void
     let onHover: (Bool) -> Void
 
     @State private var isHovered = false
-    @State private var isEditing = false
     @State private var editText = ""
     @FocusState private var fieldFocused: Bool
 
@@ -184,6 +192,12 @@ struct TabItemView: View {
                     .focused($fieldFocused)
                     .onExitCommand {
                         isEditing = false
+                    }
+                    .onChange(of: fieldFocused) {
+                        if !fieldFocused {
+                            onRename(editText.isEmpty ? nil : editText)
+                            isEditing = false
+                        }
                     }
                     .onAppear {
                         fieldFocused = true
@@ -402,8 +416,8 @@ struct TabListPopover: View {
 
 struct TabDropDelegate: DropDelegate {
     let tabManager: TabManager
-    let targetTabID: UUID
-    @Binding var draggedTabID: UUID?
+    let targetTabID: String
+    @Binding var draggedTabID: String?
 
     func performDrop(info: DropInfo) -> Bool {
         draggedTabID = nil

--- a/MaQuake/Sources/MaQuake/Tabs/TabBarView.swift
+++ b/MaQuake/Sources/MaQuake/Tabs/TabBarView.swift
@@ -68,6 +68,10 @@ struct TabBarView: View {
                     .frame(minWidth: outerGeo.size.width, alignment: .leading)
                 }
             }
+            .overlay(DoubleClickCatcher { [weak tabManager] in
+                guard let tabManager, tabManager.hoveredTabIndex == nil else { return }
+                tabManager.addTab()
+            })
 
             // Tab list button — visible when tabs overflow
             if tabsOverflow {
@@ -128,10 +132,6 @@ struct TabBarView: View {
         .frame(height: 36)
         .background(Color.black.opacity(0.85))
         .environment(\.colorScheme, .dark)
-        .overlay(DoubleClickCatcher { [weak tabManager] in
-            guard let tabManager, tabManager.hoveredTabIndex == nil else { return }
-            tabManager.addTab()
-        })
         .contentShape(Rectangle())
     }
 
@@ -333,10 +333,6 @@ final class DoubleClickNSView: NSView {
                     // on tab items without reaching high-level views (e.g. dismiss gesture)
                     while let v = current, depth < 20 {
                         if v is MouseDownNSView || v is NSButton || v is NSTextField {
-                            return event
-                        }
-                        let className = String(describing: type(of: v))
-                        if className.contains("Button") {
                             return event
                         }
                         if v.gestureRecognizers.contains(where: { $0 is NSClickGestureRecognizer }) {

--- a/MaQuake/Sources/MaQuake/Tabs/TabManager.swift
+++ b/MaQuake/Sources/MaQuake/Tabs/TabManager.swift
@@ -2,7 +2,7 @@ import Foundation
 import SwiftUI
 
 struct Tab: Identifiable {
-    let id: UUID
+    let id: String
     let kind: TabKind
     let paneManager: PaneManager?
     var title: String
@@ -25,7 +25,7 @@ struct Tab: Identifiable {
 
     /// Terminal tab
     init(directory: String? = nil) {
-        self.id = UUID()
+        self.id = generateShortID()
         self.kind = .terminal
         self.paneManager = PaneManager(directory: directory)
         self.title = "zsh"
@@ -33,7 +33,7 @@ struct Tab: Identifiable {
 
     /// Special tab (settings, help)
     init(kind: TabKind, title: String) {
-        self.id = UUID()
+        self.id = generateShortID()
         self.kind = kind
         self.paneManager = nil
         self.title = title
@@ -45,6 +45,7 @@ final class TabManager: ObservableObject {
     @Published var tabs: [Tab] = []
     @Published var activeTabIndex: Int = 0
     @Published var hoveredTabIndex: Int? = nil
+    @Published var editingTabID: String? = nil
 
     /// Stack of directories from recently closed tabs (for ⌘⇧T reopen)
     private var closedTabDirectories: [String] = []
@@ -101,7 +102,7 @@ final class TabManager: ObservableObject {
         focusTerminalInActiveTab()
     }
 
-    func closeTab(id: UUID) {
+    func closeTab(id: String) {
         guard let index = tabs.firstIndex(where: { $0.id == id }) else { return }
 
         // Save directory for ⌘⇧T reopen (terminal tabs only)
@@ -133,7 +134,7 @@ final class TabManager: ObservableObject {
         !closedTabDirectories.isEmpty
     }
 
-    func renameTab(id: UUID, name: String?) {
+    func renameTab(id: String, name: String?) {
         guard let index = tabs.firstIndex(where: { $0.id == id }) else { return }
         tabs[index].customTitle = (name?.isEmpty ?? true) ? nil : name
     }
@@ -161,7 +162,11 @@ final class TabManager: ObservableObject {
 
     func openSettings() {
         if let idx = tabs.firstIndex(where: { $0.kind == .settings }) {
-            selectTab(at: idx)
+            if activeTabIndex == idx {
+                closeTab(id: tabs[idx].id)
+            } else {
+                selectTab(at: idx)
+            }
             return
         }
         let tab = Tab(kind: .settings, title: "Settings")
@@ -171,7 +176,11 @@ final class TabManager: ObservableObject {
 
     func openHelp() {
         if let idx = tabs.firstIndex(where: { $0.kind == .help }) {
-            selectTab(at: idx)
+            if activeTabIndex == idx {
+                closeTab(id: tabs[idx].id)
+            } else {
+                selectTab(at: idx)
+            }
             return
         }
         let tab = Tab(kind: .help, title: "Help")

--- a/MaQuake/Sources/MaQuake/Terminal/GhosttyApp.swift
+++ b/MaQuake/Sources/MaQuake/Terminal/GhosttyApp.swift
@@ -104,9 +104,8 @@ final class GhosttyApp: @unchecked Sendable {
 
         runtimeConfig.read_clipboard_cb = { _, _, state in
             let contents = NSPasteboard.general.string(forType: .string) ?? ""
-            // Must find the surface to complete the request — route via app userdata
-            // For now, complete on the first available backend
             GhosttyApp.shared.completeClipboardRead(contents: contents, state: state)
+            return true
         }
 
         runtimeConfig.confirm_read_clipboard_cb = { _, _, state, _ in

--- a/MaQuake/Sources/MaQuake/Terminal/GhosttyBackend.swift
+++ b/MaQuake/Sources/MaQuake/Terminal/GhosttyBackend.swift
@@ -85,6 +85,18 @@ final class GhosttyBackend: NSObject, TerminalBackend {
         return newBackend
     }
 
+    func createSplitBackend() -> TerminalBackend? {
+        if let split = createSplitSurface() {
+            return split
+        }
+        #if DEBUG
+        // Test environment: no GPU surface, return plain backend for tree management tests
+        return GhosttyBackend()
+        #else
+        return nil
+        #endif
+    }
+
     // MARK: - Process lifecycle
 
     func startProcess(executable: String, execName: String, currentDirectory: String?) {

--- a/MaQuake/Sources/MaQuake/Terminal/TerminalBackend.swift
+++ b/MaQuake/Sources/MaQuake/Terminal/TerminalBackend.swift
@@ -31,8 +31,15 @@ protocol TerminalBackend: AnyObject {
     func send(text: String)
     func readBuffer(lineCount: Int) -> TerminalBufferSnapshot
 
+    // Split
+    func createSplitBackend() -> TerminalBackend?
+
     // Delegate
     var delegate: TerminalBackendDelegate? { get set }
+}
+
+extension TerminalBackend {
+    func createSplitBackend() -> TerminalBackend? { nil }
 }
 
 protocol TerminalBackendDelegate: AnyObject {

--- a/MaQuake/Sources/MaQuake/Terminal/TerminalContentView.swift
+++ b/MaQuake/Sources/MaQuake/Terminal/TerminalContentView.swift
@@ -85,6 +85,8 @@ final class TerminalInstance: NSObject, TerminalBackendDelegate {
     var onTitleChange: ((String) -> Void)?
     var onDirectoryChange: ((String) -> Void)?
     var onProcessTerminated: (() -> Void)?
+    var onResizeSplit: ((CGFloat) -> Void)?
+    var onEqualizeSplits: (() -> Void)?
     private(set) var currentTitle: String = "zsh"
     private(set) var currentDirectory: String = ""
     private var isTerminated = false
@@ -143,5 +145,16 @@ final class TerminalInstance: NSObject, TerminalBackendDelegate {
     func terminalProcessTerminated(exitCode: Int32?) {
         isTerminated = true
         onProcessTerminated?()
+    }
+
+    func terminalRequestedResizeSplit(direction: UInt32, amount: UInt16) {
+        // Ghostty sends amount as percentage points (e.g. 10 = 10%).
+        // Convert to ratio delta: positive = grow focused pane.
+        let delta = CGFloat(amount) / 100.0
+        onResizeSplit?(delta)
+    }
+
+    func terminalRequestedEqualizeSplits() {
+        onEqualizeSplits?()
     }
 }

--- a/MaQuake/Sources/MaQuake/Window/PanelContentView.swift
+++ b/MaQuake/Sources/MaQuake/Window/PanelContentView.swift
@@ -100,7 +100,7 @@ struct PanelContentView: View {
     }
 
     var body: some View {
-        ZStack {
+        ZStack(alignment: .topLeading) {
             // Dismiss layer
             Color.clear
                 .contentShape(Rectangle())
@@ -163,7 +163,7 @@ struct PanelContentView: View {
 
                 Spacer()
             }
-            .frame(maxWidth: .infinity)
+            .frame(width: windowController.panelWidth > 0 ? windowController.panelWidth : nil)
         }
     }
 }

--- a/MaQuake/Sources/MaQuake/Window/WindowController.swift
+++ b/MaQuake/Sources/MaQuake/Window/WindowController.swift
@@ -17,6 +17,7 @@ final class WindowController: ObservableObject {
     @Published var displayID: Int = 0
     @Published var widthPercent: Int = 75
     @Published var heightPercent: Int = 50
+    @Published var panelWidth: CGFloat = 0
 
     private var previousApp: NSRunningApplication?
     private var resignObserver: Any?
@@ -124,6 +125,7 @@ final class WindowController: ObservableObject {
             width: screen.width,
             height: screen.height
         ), display: true)
+        panelWidth = screen.width
     }
 
     // MARK: - Observers
@@ -403,16 +405,20 @@ final class WindowController: ObservableObject {
         panel.makeKeyAndOrderFront(nil)
         NSApp.activate(ignoringOtherApps: true)
 
-        if UserDefaults.standard.bool(forKey: "disableAnimation") {
-            state = .visible
-        } else {
-            withAnimation(.spring(response: 0.42, dampingFraction: 0.8, blendDuration: 0)) {
+        // Defer animation by one run loop tick so the SwiftUI hosting view
+        // picks up the new panel frame. Without this, switching monitors
+        // shows content sized/centered for the previous screen.
+        DispatchQueue.main.async { [self] in
+            if UserDefaults.standard.bool(forKey: "disableAnimation") {
                 state = .visible
+            } else {
+                withAnimation(.spring(response: 0.42, dampingFraction: 0.8, blendDuration: 0)) {
+                    state = .visible
+                }
             }
-        }
 
-        // Focus the terminal view after show
-        tabManager.focusTerminalInActiveTab()
+            tabManager.focusTerminalInActiveTab()
+        }
 
         NSHapticFeedbackManager.defaultPerformer.perform(.alignment, performanceTime: .now)
     }

--- a/MaQuake/Tests/MaQuakeTests/ControlServerTests.swift
+++ b/MaQuake/Tests/MaQuakeTests/ControlServerTests.swift
@@ -228,10 +228,10 @@ struct ControlServerHandlerTests {
     @Test func focus_bySessionID_selectsTab() {
         let (server, wc) = makeServer()
         wc.tabManager.addTab()
-        let firstTabID = wc.tabManager.tabs[0].id.uuidString
+        let firstPaneID = wc.tabManager.tabs[0].paneManager!.focusedPaneID
         wc.tabManager.selectTab(at: 1) // focus second tab
 
-        let result = server.handleRequest(json(["action": "focus", "session_id": firstTabID]))
+        let result = server.handleRequest(json(["action": "focus", "session_id": firstPaneID]))
         let parsed = parse(result)
         #expect(parsed?["ok"] as? Bool == true)
         #expect(wc.tabManager.activeTabIndex == 0)
@@ -248,7 +248,7 @@ struct ControlServerHandlerTests {
 
     @Test func focus_invalidSessionID_returnsError() {
         let (server, _) = makeServer()
-        let result = server.handleRequest(json(["action": "focus", "session_id": "00000000-0000-0000-0000-000000000000"]))
+        let result = server.handleRequest(json(["action": "focus", "session_id": "NONEXIST"]))
         let parsed = parse(result)
         #expect(parsed?["ok"] as? Bool == false)
     }
@@ -263,13 +263,13 @@ struct ControlServerHandlerTests {
 
     // MARK: - close-session
 
-    @Test func closeSession_bySessionID_closesTab() {
+    @Test func closeSession_byTabID_closesTab() {
         let (server, wc) = makeServer()
         wc.tabManager.addTab()
         #expect(wc.tabManager.tabs.count == 2)
-        let tabID = wc.tabManager.tabs[0].id.uuidString
+        let tabID = wc.tabManager.tabs[0].id
 
-        let result = server.handleRequest(json(["action": "close-session", "session_id": tabID]))
+        let result = server.handleRequest(json(["action": "close-session", "tab_id": tabID]))
         let parsed = parse(result)
         #expect(parsed?["ok"] as? Bool == true)
         // Tab closed but auto-created new one if needed
@@ -288,7 +288,7 @@ struct ControlServerHandlerTests {
 
     @Test func closeSession_invalidID_returnsError() {
         let (server, _) = makeServer()
-        let result = server.handleRequest(json(["action": "close-session", "session_id": "00000000-0000-0000-0000-000000000000"]))
+        let result = server.handleRequest(json(["action": "close-session", "session_id": "NONEXIST"]))
         let parsed = parse(result)
         #expect(parsed?["ok"] as? Bool == false)
     }
@@ -426,8 +426,8 @@ struct ControlServerHandlerTests {
 
     @Test func setAppearance_withTitle_renamesTab() {
         let (server, wc) = makeServer()
-        let tabID = wc.tabManager.tabs[0].id.uuidString
-        let result = server.handleRequest(json(["action": "set-appearance", "title": "MyTab", "session_id": tabID]))
+        let tabID = wc.tabManager.tabs[0].id
+        let result = server.handleRequest(json(["action": "set-appearance", "title": "MyTab", "tab_id": tabID]))
         let parsed = parse(result)
         #expect(parsed?["ok"] as? Bool == true)
         #expect(wc.tabManager.tabs[0].customTitle == "MyTab")
@@ -435,11 +435,11 @@ struct ControlServerHandlerTests {
 
     @Test func setAppearance_emptyTitle_clearsCustomName() {
         let (server, wc) = makeServer()
-        let tabID = wc.tabManager.tabs[0].id.uuidString
+        let tabID = wc.tabManager.tabs[0].id
         wc.tabManager.renameTab(id: wc.tabManager.tabs[0].id, name: "Custom")
         #expect(wc.tabManager.tabs[0].customTitle == "Custom")
 
-        let result = server.handleRequest(json(["action": "set-appearance", "title": "", "session_id": tabID]))
+        let result = server.handleRequest(json(["action": "set-appearance", "title": "", "tab_id": tabID]))
         let parsed = parse(result)
         #expect(parsed?["ok"] as? Bool == true)
         #expect(wc.tabManager.tabs[0].customTitle == nil)

--- a/MaQuake/Tests/MaQuakeTests/IntegrationTests.swift
+++ b/MaQuake/Tests/MaQuakeTests/IntegrationTests.swift
@@ -149,7 +149,7 @@ private enum SocketError: Error, CustomStringConvertible {
 
 /// Generate a unique temporary socket path for each test to avoid conflicts.
 private func uniqueSocketPath() -> String {
-    "/tmp/macuake-test-\(UUID().uuidString).sock"
+    "/tmp/macuake-test-\(generateShortID()).sock"
 }
 
 /// Small delay to let the socket server start accepting connections.
@@ -332,10 +332,10 @@ struct ControlServerIntegrationTests {
         defer { server.stop() }
 
         _ = try await sendCommand(["action": "new-tab"], socketPath: path)
-        let firstTabSessionID = wc.tabManager.tabs[0].id.uuidString
+        let firstPaneID = wc.tabManager.tabs[0].paneManager!.focusedPaneID
 
         let response = try await sendCommand(
-            ["action": "focus", "session_id": firstTabSessionID],
+            ["action": "focus", "session_id": firstPaneID],
             socketPath: path
         )
         #expect(response["ok"] as? Bool == true)
@@ -347,7 +347,7 @@ struct ControlServerIntegrationTests {
         defer { server.stop() }
 
         let response = try await sendCommand(
-            ["action": "focus", "session_id": UUID().uuidString],
+            ["action": "focus", "session_id": generateShortID()],
             socketPath: path
         )
         #expect(response["ok"] as? Bool == false)
@@ -363,9 +363,9 @@ struct ControlServerIntegrationTests {
         _ = try await sendCommand(["action": "new-tab"], socketPath: path)
         #expect(wc.tabManager.tabs.count == 2)
 
-        let sessionID = wc.tabManager.tabs[1].id.uuidString
+        let tabID = wc.tabManager.tabs[1].id
         let response = try await sendCommand(
-            ["action": "close-session", "session_id": sessionID],
+            ["action": "close-session", "tab_id": tabID],
             socketPath: path
         )
         #expect(response["ok"] as? Bool == true)
@@ -793,7 +793,7 @@ struct ControlServerExecuteReadTests {
         let (server, wc, path) = try await makeServerAndController()
         defer { server.stop() }
 
-        let sessionID = wc.tabManager.tabs[0].id.uuidString
+        let sessionID = wc.tabManager.tabs[0].paneManager!.focusedPaneID
 
         let response = try await sendCommand(
             ["action": "execute", "command": "pwd", "session_id": sessionID],
@@ -864,7 +864,7 @@ struct ControlServerExecuteReadTests {
         defer { server.stop() }
 
         let response = try await sendCommand(
-            ["action": "read", "session_id": UUID().uuidString],
+            ["action": "read", "session_id": generateShortID()],
             socketPath: path
         )
         #expect(response["ok"] as? Bool == false)

--- a/MaQuake/Tests/MaQuakeTests/PaneManagementTests.swift
+++ b/MaQuake/Tests/MaQuakeTests/PaneManagementTests.swift
@@ -242,6 +242,81 @@ struct PaneIntegrationTests {
 
     @Test func backend_forInvalidID_returnsNil() {
         let pm = PaneManager()
-        #expect(pm.rootPane.backend(for: UUID()) == nil)
+        #expect(pm.rootPane.backend(for: "NONEXIST") == nil)
+    }
+
+    // MARK: - Resize splits
+
+    @Test func updateSplitRatio_changesRatio() throws {
+        let pm = PaneManager()
+        try #require(pm.splitFocusedPane(axis: .horizontal))
+
+        guard case .split(let splitID, _, _, _, let ratio) = pm.rootPane else {
+            Issue.record("Expected split root"); return
+        }
+        #expect(abs(ratio - 0.5) < 0.001)
+
+        pm.updateSplitRatio(splitID: splitID, ratio: 0.7)
+
+        if case .split(_, _, _, _, let newRatio) = pm.rootPane {
+            #expect(abs(newRatio - 0.7) < 0.001)
+        }
+    }
+
+    @Test func resizeFocusedSplit_growsFocusedPane() throws {
+        let pm = PaneManager()
+        let firstID = pm.focusedPaneID
+        try #require(pm.splitFocusedPane(axis: .horizontal))
+        // Focus is on second pane. Grow it by +0.1 → ratio decreases (second gets more space)
+        pm.resizeFocusedSplit(delta: 0.1)
+
+        if case .split(_, _, _, _, let ratio) = pm.rootPane {
+            #expect(ratio < 0.5, "Second pane growing means first pane's ratio shrinks")
+        }
+    }
+
+    @Test func resizeFocusedSplit_firstPane_growsRatio() throws {
+        let pm = PaneManager()
+        let firstID = pm.focusedPaneID
+        try #require(pm.splitFocusedPane(axis: .horizontal))
+        // Switch focus to first pane
+        pm.focusedPaneID = firstID
+        pm.resizeFocusedSplit(delta: 0.1)
+
+        if case .split(_, _, _, _, let ratio) = pm.rootPane {
+            #expect(ratio > 0.5, "First pane growing means ratio increases")
+        }
+    }
+
+    @Test func resizeFocusedSplit_singlePane_noOp() {
+        let pm = PaneManager()
+        // Should not crash with single pane
+        pm.resizeFocusedSplit(delta: 0.1)
+        #expect(pm.rootPane.leafCount == 1)
+    }
+
+    @Test func equalizeSplits_resetsAllRatios() throws {
+        let pm = PaneManager()
+        try #require(pm.splitFocusedPane(axis: .horizontal))
+
+        // Change ratio away from 0.5
+        if case .split(let splitID, _, _, _, _) = pm.rootPane {
+            pm.updateSplitRatio(splitID: splitID, ratio: 0.3)
+        }
+
+        pm.equalizeSplits()
+
+        if case .split(_, _, _, _, let ratio) = pm.rootPane {
+            #expect(abs(ratio - 0.5) < 0.001)
+        }
+    }
+
+    @Test func splitPane_customRatio_applied() throws {
+        let pm = PaneManager()
+        try #require(pm.splitFocusedPane(axis: .horizontal, ratio: 0.7))
+
+        if case .split(_, _, _, _, let ratio) = pm.rootPane {
+            #expect(abs(ratio - 0.7) < 0.001)
+        }
     }
 }

--- a/MaQuake/Tests/MaQuakeTests/PaneNodeTreeTests.swift
+++ b/MaQuake/Tests/MaQuakeTests/PaneNodeTreeTests.swift
@@ -15,8 +15,8 @@ struct PaneNodeTreeTests {
         GhosttyBackend()
     }
 
-    private func makeLeaf() -> (PaneNode, UUID, GhosttyBackend) {
-        let id = UUID()
+    private func makeLeaf() -> (PaneNode, String, GhosttyBackend) {
+        let id = generateShortID()
         let backend = makeBackend()
         return (.leaf(id: id, backend: backend), id, backend)
     }
@@ -40,21 +40,21 @@ struct PaneNodeTreeTests {
 
     @Test func leaf_backend_invalidID_returnsNil() {
         let (node, _, _) = makeLeaf()
-        #expect(node.backend(for: UUID()) == nil)
+        #expect(node.backend(for: generateShortID()) == nil)
     }
 
     @Test func split_leafCount_sumOfChildren() {
         let (leaf1, _, _) = makeLeaf()
         let (leaf2, _, _) = makeLeaf()
-        let split = PaneNode.split(id: UUID(), axis: .horizontal, first: leaf1, second: leaf2, ratio: 0.5)
+        let split = PaneNode.split(id: generateShortID(), axis: .horizontal, first: leaf1, second: leaf2, ratio: 0.5)
         #expect(split.leafCount == 2)
     }
 
     @Test func split_leafIDs_ordered() {
-        let id1 = UUID(), id2 = UUID()
+        let id1 = generateShortID(), id2 = generateShortID()
         let b1 = makeBackend(), b2 = makeBackend()
         let split = PaneNode.split(
-            id: UUID(), axis: .horizontal,
+            id: generateShortID(), axis: .horizontal,
             first: .leaf(id: id1, backend: b1),
             second: .leaf(id: id2, backend: b2),
             ratio: 0.5
@@ -63,16 +63,16 @@ struct PaneNodeTreeTests {
     }
 
     @Test func nestedSplit_leafIDs_orderedDepthFirst() {
-        let id1 = UUID(), id2 = UUID(), id3 = UUID()
+        let id1 = generateShortID(), id2 = generateShortID(), id3 = generateShortID()
         let b1 = makeBackend(), b2 = makeBackend(), b3 = makeBackend()
         let inner = PaneNode.split(
-            id: UUID(), axis: .vertical,
+            id: generateShortID(), axis: .vertical,
             first: .leaf(id: id2, backend: b2),
             second: .leaf(id: id3, backend: b3),
             ratio: 0.5
         )
         let outer = PaneNode.split(
-            id: UUID(), axis: .horizontal,
+            id: generateShortID(), axis: .horizontal,
             first: .leaf(id: id1, backend: b1),
             second: inner,
             ratio: 0.5
@@ -82,17 +82,17 @@ struct PaneNodeTreeTests {
     }
 
     @Test func split_backend_findsInEitherSubtree() {
-        let id1 = UUID(), id2 = UUID()
+        let id1 = generateShortID(), id2 = generateShortID()
         let b1 = makeBackend(), b2 = makeBackend()
         let split = PaneNode.split(
-            id: UUID(), axis: .horizontal,
+            id: generateShortID(), axis: .horizontal,
             first: .leaf(id: id1, backend: b1),
             second: .leaf(id: id2, backend: b2),
             ratio: 0.5
         )
         #expect(split.backend(for: id1) === b1)
         #expect(split.backend(for: id2) === b2)
-        #expect(split.backend(for: UUID()) == nil)
+        #expect(split.backend(for: generateShortID()) == nil)
     }
 
     // MARK: - splitNode
@@ -100,7 +100,7 @@ struct PaneNodeTreeTests {
     @Test func splitNode_leafMatchesTarget_returnsSplit() {
         let (leaf, id, _) = makeLeaf()
         let newBackend = makeBackend()
-        let newID = UUID()
+        let newID = generateShortID()
 
         let result = splitNode(leaf, targetID: id, axis: .horizontal, newBackend: newBackend, newPaneID: newID)
 
@@ -111,7 +111,7 @@ struct PaneNodeTreeTests {
     @Test func splitNode_leafNotMatching_returnsUnchanged() {
         let (leaf, id, _) = makeLeaf()
         let newBackend = makeBackend()
-        let result = splitNode(leaf, targetID: UUID(), axis: .horizontal, newBackend: newBackend, newPaneID: UUID())
+        let result = splitNode(leaf, targetID: generateShortID(), axis: .horizontal, newBackend: newBackend, newPaneID: generateShortID())
 
         #expect(result.leafCount == 1)
         #expect(result.leafIDs == [id])
@@ -120,7 +120,7 @@ struct PaneNodeTreeTests {
     @Test func splitNode_preservesOriginalLeafID() {
         let (leaf, id, backend) = makeLeaf()
         let newBackend = makeBackend()
-        let newID = UUID()
+        let newID = generateShortID()
 
         let result = splitNode(leaf, targetID: id, axis: .vertical, newBackend: newBackend, newPaneID: newID)
 
@@ -129,11 +129,11 @@ struct PaneNodeTreeTests {
         #expect(result.backend(for: newID) === newBackend)
     }
 
-    @Test func splitNode_createsNewSplitUUID() {
+    @Test func splitNode_createsNewSplitgenerateShortID() {
         let (leaf, id, _) = makeLeaf()
         let newBackend = makeBackend()
 
-        let result = splitNode(leaf, targetID: id, axis: .horizontal, newBackend: newBackend, newPaneID: UUID())
+        let result = splitNode(leaf, targetID: id, axis: .horizontal, newBackend: newBackend, newPaneID: generateShortID())
 
         // Split node should have a new UUID, different from the leaf
         #expect(result.id != id)
@@ -142,7 +142,7 @@ struct PaneNodeTreeTests {
     @Test func splitNode_ratio_isHalf() {
         let (leaf, id, _) = makeLeaf()
         let newBackend = makeBackend()
-        let result = splitNode(leaf, targetID: id, axis: .horizontal, newBackend: newBackend, newPaneID: UUID())
+        let result = splitNode(leaf, targetID: id, axis: .horizontal, newBackend: newBackend, newPaneID: generateShortID())
 
         if case .split(_, _, _, _, let ratio) = result {
             #expect(ratio == 0.5)
@@ -152,17 +152,17 @@ struct PaneNodeTreeTests {
     }
 
     @Test func splitNode_targetInFirstSubtree_onlyFirstModified() {
-        let id1 = UUID(), id2 = UUID()
+        let id1 = generateShortID(), id2 = generateShortID()
         let b1 = makeBackend(), b2 = makeBackend()
         let tree = PaneNode.split(
-            id: UUID(), axis: .horizontal,
+            id: generateShortID(), axis: .horizontal,
             first: .leaf(id: id1, backend: b1),
             second: .leaf(id: id2, backend: b2),
             ratio: 0.5
         )
 
         let newBackend = makeBackend()
-        let newID = UUID()
+        let newID = generateShortID()
         let result = splitNode(tree, targetID: id1, axis: .vertical, newBackend: newBackend, newPaneID: newID)
 
         #expect(result.leafCount == 3)
@@ -170,17 +170,17 @@ struct PaneNodeTreeTests {
     }
 
     @Test func splitNode_targetInSecondSubtree_onlySecondModified() {
-        let id1 = UUID(), id2 = UUID()
+        let id1 = generateShortID(), id2 = generateShortID()
         let b1 = makeBackend(), b2 = makeBackend()
         let tree = PaneNode.split(
-            id: UUID(), axis: .horizontal,
+            id: generateShortID(), axis: .horizontal,
             first: .leaf(id: id1, backend: b1),
             second: .leaf(id: id2, backend: b2),
             ratio: 0.5
         )
 
         let newBackend = makeBackend()
-        let newID = UUID()
+        let newID = generateShortID()
         let result = splitNode(tree, targetID: id2, axis: .vertical, newBackend: newBackend, newPaneID: newID)
 
         #expect(result.leafCount == 3)
@@ -189,23 +189,23 @@ struct PaneNodeTreeTests {
 
     @Test func splitNode_deepNesting_correctlyRecurses() {
         // Create a 3-level deep tree and split the deepest leaf
-        let id1 = UUID(), id2 = UUID(), id3 = UUID()
+        let id1 = generateShortID(), id2 = generateShortID(), id3 = generateShortID()
         let b1 = makeBackend(), b2 = makeBackend(), b3 = makeBackend()
         let inner = PaneNode.split(
-            id: UUID(), axis: .vertical,
+            id: generateShortID(), axis: .vertical,
             first: .leaf(id: id2, backend: b2),
             second: .leaf(id: id3, backend: b3),
             ratio: 0.5
         )
         let outer = PaneNode.split(
-            id: UUID(), axis: .horizontal,
+            id: generateShortID(), axis: .horizontal,
             first: .leaf(id: id1, backend: b1),
             second: inner,
             ratio: 0.5
         )
 
         let newBackend = makeBackend()
-        let newID = UUID()
+        let newID = generateShortID()
         let result = splitNode(outer, targetID: id3, axis: .horizontal, newBackend: newBackend, newPaneID: newID)
 
         #expect(result.leafCount == 4)
@@ -222,16 +222,16 @@ struct PaneNodeTreeTests {
 
     @Test func removeNode_leafNotMatching_returnsUnchanged() {
         let (leaf, id, _) = makeLeaf()
-        let result = removeNode(leaf, targetID: UUID())
+        let result = removeNode(leaf, targetID: generateShortID())
         #expect(result != nil)
         #expect(result?.leafIDs == [id])
     }
 
     @Test func removeNode_firstOfTwo_collapsesToSecond() {
-        let id1 = UUID(), id2 = UUID()
+        let id1 = generateShortID(), id2 = generateShortID()
         let b1 = makeBackend(), b2 = makeBackend()
         let tree = PaneNode.split(
-            id: UUID(), axis: .horizontal,
+            id: generateShortID(), axis: .horizontal,
             first: .leaf(id: id1, backend: b1),
             second: .leaf(id: id2, backend: b2),
             ratio: 0.5
@@ -244,10 +244,10 @@ struct PaneNodeTreeTests {
     }
 
     @Test func removeNode_secondOfTwo_collapsesToFirst() {
-        let id1 = UUID(), id2 = UUID()
+        let id1 = generateShortID(), id2 = generateShortID()
         let b1 = makeBackend(), b2 = makeBackend()
         let tree = PaneNode.split(
-            id: UUID(), axis: .horizontal,
+            id: generateShortID(), axis: .horizontal,
             first: .leaf(id: id1, backend: b1),
             second: .leaf(id: id2, backend: b2),
             ratio: 0.5
@@ -260,16 +260,16 @@ struct PaneNodeTreeTests {
     }
 
     @Test func removeNode_fromThreeLeaves_rebuildsCorrectly() {
-        let id1 = UUID(), id2 = UUID(), id3 = UUID()
+        let id1 = generateShortID(), id2 = generateShortID(), id3 = generateShortID()
         let b1 = makeBackend(), b2 = makeBackend(), b3 = makeBackend()
         let inner = PaneNode.split(
-            id: UUID(), axis: .vertical,
+            id: generateShortID(), axis: .vertical,
             first: .leaf(id: id2, backend: b2),
             second: .leaf(id: id3, backend: b3),
             ratio: 0.5
         )
         let tree = PaneNode.split(
-            id: UUID(), axis: .horizontal,
+            id: generateShortID(), axis: .horizontal,
             first: .leaf(id: id1, backend: b1),
             second: inner,
             ratio: 0.5
@@ -283,23 +283,23 @@ struct PaneNodeTreeTests {
     }
 
     @Test func removeNode_deeplyNested_collapseCorrectly() {
-        let id1 = UUID(), id2 = UUID(), id3 = UUID(), id4 = UUID()
+        let id1 = generateShortID(), id2 = generateShortID(), id3 = generateShortID(), id4 = generateShortID()
         let b1 = makeBackend(), b2 = makeBackend(), b3 = makeBackend(), b4 = makeBackend()
 
         let innerRight = PaneNode.split(
-            id: UUID(), axis: .vertical,
+            id: generateShortID(), axis: .vertical,
             first: .leaf(id: id3, backend: b3),
             second: .leaf(id: id4, backend: b4),
             ratio: 0.5
         )
         let innerLeft = PaneNode.split(
-            id: UUID(), axis: .vertical,
+            id: generateShortID(), axis: .vertical,
             first: .leaf(id: id1, backend: b1),
             second: .leaf(id: id2, backend: b2),
             ratio: 0.5
         )
         let tree = PaneNode.split(
-            id: UUID(), axis: .horizontal,
+            id: generateShortID(), axis: .horizontal,
             first: innerLeft,
             second: innerRight,
             ratio: 0.5
@@ -313,16 +313,16 @@ struct PaneNodeTreeTests {
     }
 
     @Test func removeNode_nonExistentTarget_returnsUnchanged() {
-        let id1 = UUID(), id2 = UUID()
+        let id1 = generateShortID(), id2 = generateShortID()
         let b1 = makeBackend(), b2 = makeBackend()
         let tree = PaneNode.split(
-            id: UUID(), axis: .horizontal,
+            id: generateShortID(), axis: .horizontal,
             first: .leaf(id: id1, backend: b1),
             second: .leaf(id: id2, backend: b2),
             ratio: 0.5
         )
 
-        let result = removeNode(tree, targetID: UUID())
+        let result = removeNode(tree, targetID: generateShortID())
         #expect(result != nil)
         #expect(result?.leafCount == 2)
         #expect(result?.leafIDs == [id1, id2])
@@ -337,16 +337,16 @@ struct PaneNodeTreeTests {
     }
 
     @Test func terminateAll_multipleLeaves_noCrash() {
-        let id1 = UUID(), id2 = UUID(), id3 = UUID()
+        let id1 = generateShortID(), id2 = generateShortID(), id3 = generateShortID()
         let b1 = makeBackend(), b2 = makeBackend(), b3 = makeBackend()
         let inner = PaneNode.split(
-            id: UUID(), axis: .vertical,
+            id: generateShortID(), axis: .vertical,
             first: .leaf(id: id2, backend: b2),
             second: .leaf(id: id3, backend: b3),
             ratio: 0.5
         )
         let tree = PaneNode.split(
-            id: UUID(), axis: .horizontal,
+            id: generateShortID(), axis: .horizontal,
             first: .leaf(id: id1, backend: b1),
             second: inner,
             ratio: 0.5
@@ -361,25 +361,217 @@ struct PaneNodeTreeTests {
         let (leaf, id, _) = makeLeaf()
         let newBackend = makeBackend()
 
-        let resultH = splitNode(leaf, targetID: id, axis: .horizontal, newBackend: newBackend, newPaneID: UUID())
+        let resultH = splitNode(leaf, targetID: id, axis: .horizontal, newBackend: newBackend, newPaneID: generateShortID())
         if case .split(_, let axis, _, _, _) = resultH {
             #expect(axis == .horizontal)
         }
 
         let (leaf2, id2, _) = makeLeaf()
-        let resultV = splitNode(leaf2, targetID: id2, axis: .vertical, newBackend: makeBackend(), newPaneID: UUID())
+        let resultV = splitNode(leaf2, targetID: id2, axis: .vertical, newBackend: makeBackend(), newPaneID: generateShortID())
         if case .split(_, let axis, _, _, _) = resultV {
             #expect(axis == .vertical)
         }
     }
 
     @Test func paneNode_id_isAccessible() {
-        let leafID = UUID()
+        let leafID = generateShortID()
         let leaf = PaneNode.leaf(id: leafID, backend: makeBackend())
         #expect(leaf.id == leafID)
 
-        let splitID = UUID()
+        let splitID = generateShortID()
         let split = PaneNode.split(id: splitID, axis: .horizontal, first: leaf, second: leaf, ratio: 0.5)
         #expect(split.id == splitID)
+    }
+
+    // MARK: - updateRatio
+
+    @Test func updateRatio_changesTargetSplit() {
+        let id1 = generateShortID(), id2 = generateShortID()
+        let b1 = makeBackend(), b2 = makeBackend()
+        let splitID = generateShortID()
+        let tree = PaneNode.split(
+            id: splitID, axis: .horizontal,
+            first: .leaf(id: id1, backend: b1),
+            second: .leaf(id: id2, backend: b2),
+            ratio: 0.5
+        )
+
+        let result = updateRatio(tree, splitID: splitID, ratio: 0.7)
+        if case .split(_, _, _, _, let r) = result {
+            #expect(abs(r - 0.7) < 0.001)
+        } else {
+            Issue.record("Expected split node")
+        }
+    }
+
+    @Test func updateRatio_clampsToMinMax() {
+        let splitID = generateShortID()
+        let tree = PaneNode.split(
+            id: splitID, axis: .horizontal,
+            first: .leaf(id: generateShortID(), backend: makeBackend()),
+            second: .leaf(id: generateShortID(), backend: makeBackend()),
+            ratio: 0.5
+        )
+
+        // Below minimum (0.1)
+        let low = updateRatio(tree, splitID: splitID, ratio: 0.0)
+        if case .split(_, _, _, _, let r) = low {
+            #expect(abs(r - 0.1) < 0.001)
+        }
+
+        // Above maximum (0.9)
+        let high = updateRatio(tree, splitID: splitID, ratio: 1.0)
+        if case .split(_, _, _, _, let r) = high {
+            #expect(abs(r - 0.9) < 0.001)
+        }
+    }
+
+    @Test func updateRatio_nonMatchingSplitID_unchanged() {
+        let splitID = generateShortID()
+        let tree = PaneNode.split(
+            id: splitID, axis: .horizontal,
+            first: .leaf(id: generateShortID(), backend: makeBackend()),
+            second: .leaf(id: generateShortID(), backend: makeBackend()),
+            ratio: 0.5
+        )
+
+        let result = updateRatio(tree, splitID: generateShortID(), ratio: 0.8)
+        if case .split(_, _, _, _, let r) = result {
+            #expect(abs(r - 0.5) < 0.001)
+        }
+    }
+
+    @Test func updateRatio_nestedSplit_updatesCorrectOne() {
+        let innerID = generateShortID()
+        let outerID = generateShortID()
+        let inner = PaneNode.split(
+            id: innerID, axis: .vertical,
+            first: .leaf(id: generateShortID(), backend: makeBackend()),
+            second: .leaf(id: generateShortID(), backend: makeBackend()),
+            ratio: 0.5
+        )
+        let tree = PaneNode.split(
+            id: outerID, axis: .horizontal,
+            first: .leaf(id: generateShortID(), backend: makeBackend()),
+            second: inner,
+            ratio: 0.5
+        )
+
+        let result = updateRatio(tree, splitID: innerID, ratio: 0.3)
+        // Outer should be unchanged
+        if case .split(_, _, _, let second, let outerR) = result {
+            #expect(abs(outerR - 0.5) < 0.001)
+            // Inner should be updated
+            if case .split(_, _, _, _, let innerR) = second {
+                #expect(abs(innerR - 0.3) < 0.001)
+            }
+        }
+    }
+
+    // MARK: - parentSplitID
+
+    @Test func parentSplitID_directChild_returnsSplitID() {
+        let id1 = generateShortID(), id2 = generateShortID()
+        let splitID = generateShortID()
+        let tree = PaneNode.split(
+            id: splitID, axis: .horizontal,
+            first: .leaf(id: id1, backend: makeBackend()),
+            second: .leaf(id: id2, backend: makeBackend()),
+            ratio: 0.5
+        )
+
+        #expect(parentSplitID(of: id1, in: tree) == splitID)
+        #expect(parentSplitID(of: id2, in: tree) == splitID)
+    }
+
+    @Test func parentSplitID_nestedChild_returnsInnerSplitID() {
+        let id1 = generateShortID(), id2 = generateShortID(), id3 = generateShortID()
+        let innerID = generateShortID()
+        let inner = PaneNode.split(
+            id: innerID, axis: .vertical,
+            first: .leaf(id: id2, backend: makeBackend()),
+            second: .leaf(id: id3, backend: makeBackend()),
+            ratio: 0.5
+        )
+        let tree = PaneNode.split(
+            id: generateShortID(), axis: .horizontal,
+            first: .leaf(id: id1, backend: makeBackend()),
+            second: inner,
+            ratio: 0.5
+        )
+
+        #expect(parentSplitID(of: id2, in: tree) == innerID)
+        #expect(parentSplitID(of: id3, in: tree) == innerID)
+    }
+
+    @Test func parentSplitID_singleLeaf_returnsNil() {
+        let id = generateShortID()
+        let leaf = PaneNode.leaf(id: id, backend: makeBackend())
+        #expect(parentSplitID(of: id, in: leaf) == nil)
+    }
+
+    @Test func parentSplitID_nonExistentPane_returnsNil() {
+        let tree = PaneNode.split(
+            id: generateShortID(), axis: .horizontal,
+            first: .leaf(id: generateShortID(), backend: makeBackend()),
+            second: .leaf(id: generateShortID(), backend: makeBackend()),
+            ratio: 0.5
+        )
+        #expect(parentSplitID(of: generateShortID(), in: tree) == nil)
+    }
+
+    // MARK: - equalizeRatios
+
+    @Test func equalizeRatios_setsAllToHalf() {
+        let innerID = generateShortID()
+        let inner = PaneNode.split(
+            id: innerID, axis: .vertical,
+            first: .leaf(id: generateShortID(), backend: makeBackend()),
+            second: .leaf(id: generateShortID(), backend: makeBackend()),
+            ratio: 0.3
+        )
+        let tree = PaneNode.split(
+            id: generateShortID(), axis: .horizontal,
+            first: .leaf(id: generateShortID(), backend: makeBackend()),
+            second: inner,
+            ratio: 0.7
+        )
+
+        let result = equalizeRatios(tree)
+        if case .split(_, _, _, let second, let outerR) = result {
+            #expect(abs(outerR - 0.5) < 0.001)
+            if case .split(_, _, _, _, let innerR) = second {
+                #expect(abs(innerR - 0.5) < 0.001)
+            }
+        }
+    }
+
+    @Test func equalizeRatios_leaf_returnsUnchanged() {
+        let (leaf, id, _) = makeLeaf()
+        let result = equalizeRatios(leaf)
+        #expect(result.leafIDs == [id])
+    }
+
+    // MARK: - splitNode with custom ratio
+
+    @Test func splitNode_customRatio_applied() {
+        let (leaf, id, _) = makeLeaf()
+        let newBackend = makeBackend()
+        let newID = generateShortID()
+
+        let result = splitNode(leaf, targetID: id, axis: .horizontal, newBackend: newBackend, newPaneID: newID, ratio: 0.7)
+        if case .split(_, _, _, _, let r) = result {
+            #expect(abs(r - 0.7) < 0.001)
+        }
+    }
+
+    @Test func splitNode_defaultRatio_isHalf() {
+        let (leaf, id, _) = makeLeaf()
+        let newBackend = makeBackend()
+
+        let result = splitNode(leaf, targetID: id, axis: .horizontal, newBackend: newBackend, newPaneID: generateShortID())
+        if case .split(_, _, _, _, let r) = result {
+            #expect(abs(r - 0.5) < 0.001)
+        }
     }
 }

--- a/MaQuake/Tests/MaQuakeTests/TabManagerTests.swift
+++ b/MaQuake/Tests/MaQuakeTests/TabManagerTests.swift
@@ -84,7 +84,7 @@ struct TabManagerTests {
     @Test func closeTab_withInvalidID_doesNothing() {
         let manager = TabManager()
         let countBefore = manager.tabs.count
-        manager.closeTab(id: UUID())
+        manager.closeTab(id: "NONEXIST")
         #expect(manager.tabs.count == countBefore)
     }
 

--- a/MaQuake/Tests/MaQuakeTests/TabTests.swift
+++ b/MaQuake/Tests/MaQuakeTests/TabTests.swift
@@ -31,7 +31,7 @@ struct TabTests {
     @Test func tab_identifiable_conformance() {
         let tab = Tab()
         // Tab conforms to Identifiable through its `id` property
-        let id: UUID = tab.id
+        let id: String = tab.id
         #expect(id == tab.id)
     }
 }

--- a/scripts/build-ghostty.sh
+++ b/scripts/build-ghostty.sh
@@ -53,5 +53,48 @@ if [ ! -d "$XCFRAMEWORK_DIR" ]; then
     exit 1
 fi
 
+# Xcode 26 libtool (cctools_ld-1267) silently drops .o files that aren't
+# 8-byte aligned; zig 0.15.x emits misaligned objects. Rebuild each
+# platform library from the intermediate .a files using ar (no alignment check).
+for lib_dir in "$XCFRAMEWORK_DIR"/*/; do
+    fat_lib="$lib_dir/libghostty-fat.a"
+    [ -f "$fat_lib" ] || continue
+
+    fat_sym_count=$(nm "$fat_lib" 2>/dev/null | grep -c " T _ghostty_app_new" || true)
+    if [ "$fat_sym_count" -gt 0 ]; then
+        continue
+    fi
+
+    echo "Rebuilding $(basename "$lib_dir")/libghostty-fat.a (libtool dropped misaligned objects)..."
+    MERGE_DIR=$(mktemp -d)
+
+    # Extract all intermediate .a files from zig-cache, in order: dependencies first, ghostty last
+    for archive in "$GHOSTTY_DIR"/.zig-cache/o/*/lib*.a; do
+        [ -f "$archive" ] || continue
+        base=$(basename "$archive")
+        # Skip the fat lib itself and shared lib stubs
+        [ "$base" = "libghostty-fat.a" ] && continue
+        echo "$base" | grep -q "libghostty-vt" && continue
+        # Extract to a subdir to avoid name collisions, then move with unique prefix
+        SUB=$(mktemp -d)
+        (cd "$SUB" && ar x "$archive" && chmod 644 *.o 2>/dev/null || true)
+        for obj in "$SUB"/*.o; do
+            [ -f "$obj" ] || continue
+            name=$(basename "$obj")
+            if [ ! -f "$MERGE_DIR/$name" ]; then
+                mv "$obj" "$MERGE_DIR/$name"
+            fi
+        done
+        rm -rf "$SUB"
+    done
+
+    obj_count=$(ls "$MERGE_DIR"/*.o 2>/dev/null | wc -l | tr -d ' ')
+    ar rcs "$fat_lib" "$MERGE_DIR"/*.o
+    ranlib "$fat_lib"
+    rm -rf "$MERGE_DIR"
+    ghostty_syms=$(nm "$fat_lib" 2>/dev/null | grep -c ' T _ghostty' || echo 0)
+    echo "  Done: $obj_count objects, $ghostty_syms ghostty symbols"
+done
+
 echo "$CURRENT_SHA" > "$CACHE_FILE"
 echo "Build complete: $XCFRAMEWORK_DIR"

--- a/scripts/build-install.sh
+++ b/scripts/build-install.sh
@@ -13,8 +13,14 @@ SIGNING_IDENTITY="Developer ID Application: Denti.AI Technology Inc (45N4N4R4C3)
 
 cd "$PROJECT_ROOT"
 
-echo "==> Building universal release (arm64 + x86_64)..."
-swift build --build-system xcode -c release --arch arm64 --arch x86_64
+ARCH="${1:---arch arm64}"
+if [ "$ARCH" = "--universal" ]; then
+    echo "==> Building universal release (arm64 + x86_64)..."
+    swift build --build-system xcode -c release --arch arm64 --arch x86_64
+else
+    echo "==> Building release (arm64)..."
+    swift build --build-system xcode -c release --arch arm64
+fi
 
 echo "==> Copying binary..."
 cp .build/apple/Products/Release/Macuake "$BINARY"
@@ -58,29 +64,38 @@ fi
 echo "==> Fixing rpath for embedded frameworks..."
 install_name_tool -add_rpath "@executable_path/../Frameworks" "$BINARY" 2>/dev/null || true
 
-echo "==> Signing (inside-out) with: $SIGNING_IDENTITY"
+# Check if signing identity is available; fall back to ad-hoc for dev builds
+if security find-identity -v -p codesigning | grep -q "$SIGNING_IDENTITY"; then
+    SIGN_ID="$SIGNING_IDENTITY"
+    SIGN_OPTS="--options runtime"
+    echo "==> Signing (inside-out) with: $SIGN_ID"
+else
+    SIGN_ID="-"
+    SIGN_OPTS=""
+    echo "==> Signing (ad-hoc, Developer ID not found)"
+fi
 
 # Sign resource bundles in Resources/
 for bundle in "$APP_BUNDLE"/Contents/Resources/*.bundle; do
     [ -d "$bundle" ] || continue
-    codesign --force --sign "$SIGNING_IDENTITY" "$bundle"
+    codesign --force --sign "$SIGN_ID" "$bundle"
 done
 
 # Sign Sparkle components inside-out
-codesign --force --sign "$SIGNING_IDENTITY" --options runtime \
+codesign --force --sign "$SIGN_ID" $SIGN_OPTS \
     "$APP_BUNDLE/Contents/Frameworks/Sparkle.framework/Versions/B/XPCServices/Installer.xpc"
-codesign --force --sign "$SIGNING_IDENTITY" --options runtime \
+codesign --force --sign "$SIGN_ID" $SIGN_OPTS \
     "$APP_BUNDLE/Contents/Frameworks/Sparkle.framework/Versions/B/XPCServices/Downloader.xpc"
-codesign --force --sign "$SIGNING_IDENTITY" --options runtime \
+codesign --force --sign "$SIGN_ID" $SIGN_OPTS \
     "$APP_BUNDLE/Contents/Frameworks/Sparkle.framework/Versions/B/Autoupdate"
-codesign --force --sign "$SIGNING_IDENTITY" --options runtime \
+codesign --force --sign "$SIGN_ID" $SIGN_OPTS \
     "$APP_BUNDLE/Contents/Frameworks/Sparkle.framework/Versions/B/Updater.app"
-codesign --force --sign "$SIGNING_IDENTITY" --options runtime \
+codesign --force --sign "$SIGN_ID" $SIGN_OPTS \
     "$APP_BUNDLE/Contents/Frameworks/Sparkle.framework"
 
 # Sign main app bundle last
-codesign --force --sign "$SIGNING_IDENTITY" \
-    --options runtime \
+codesign --force --sign "$SIGN_ID" \
+    $SIGN_OPTS \
     --entitlements "$ENTITLEMENTS" \
     "$APP_BUNDLE"
 
@@ -95,7 +110,8 @@ sleep 0.3
 rm -rf "/Applications/${INSTALL_NAME}.app"
 cp -R "$APP_BUNDLE" "/Applications/${INSTALL_NAME}.app"
 mv "/Applications/${INSTALL_NAME}.app/Contents/MacOS/Macuake" "/Applications/${INSTALL_NAME}.app/Contents/MacOS/${INSTALL_NAME}"
-/usr/libexec/PlistBuddy -c "Set :CFBundleExecutable ${INSTALL_NAME}" "/Applications/${INSTALL_NAME}.app/Contents/Info.plist"
+/usr/libexec/PlistBuddy -c "Set :CFBundleExecutable ${INSTALL_NAME}" "/Applications/${INSTALL_NAME}.app/Contents/Info.plist" 2>/dev/null \
+    || /usr/libexec/PlistBuddy -c "Add :CFBundleExecutable string ${INSTALL_NAME}" "/Applications/${INSTALL_NAME}.app/Contents/Info.plist"
 echo "==> Installed: /Applications/${INSTALL_NAME}.app"
 
 echo "Done."

--- a/scripts/build-install.sh
+++ b/scripts/build-install.sh
@@ -38,6 +38,12 @@ for bundle in .build/apple/Products/Release/*.bundle; do
     echo "    $name"
 done
 
+echo "==> Removing stale bundles from app root..."
+for bundle in "$APP_BUNDLE"/*.bundle; do
+    [ -d "$bundle" ] || continue
+    rm -rf "$bundle"
+done
+
 echo "==> Embedding Sparkle.framework..."
 FRAMEWORKS_DIR="$APP_BUNDLE/Contents/Frameworks"
 mkdir -p "$FRAMEWORKS_DIR"
@@ -81,12 +87,15 @@ codesign --force --sign "$SIGNING_IDENTITY" \
 codesign --verify --deep --strict "$APP_BUNDLE"
 echo "==> Signed and verified: $APP_BUNDLE"
 
-# Always install: kill running instance, force-replace, relaunch
-echo "==> Installing to /Applications..."
-killall Macuake 2>/dev/null || true
+# Install as Macuake_dev.app to avoid conflicting with brew-installed Macuake.app
+INSTALL_NAME="Macuake_dev"
+echo "==> Installing to /Applications/${INSTALL_NAME}.app..."
+killall "$INSTALL_NAME" 2>/dev/null || true
 sleep 0.3
-rm -rf /Applications/Macuake.app
-cp -R "$APP_BUNDLE" /Applications/Macuake.app
-echo "==> Installed: /Applications/Macuake.app"
+rm -rf "/Applications/${INSTALL_NAME}.app"
+cp -R "$APP_BUNDLE" "/Applications/${INSTALL_NAME}.app"
+mv "/Applications/${INSTALL_NAME}.app/Contents/MacOS/Macuake" "/Applications/${INSTALL_NAME}.app/Contents/MacOS/${INSTALL_NAME}"
+/usr/libexec/PlistBuddy -c "Set :CFBundleExecutable ${INSTALL_NAME}" "/Applications/${INSTALL_NAME}.app/Contents/Info.plist"
+echo "==> Installed: /Applications/${INSTALL_NAME}.app"
 
 echo "Done."

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -40,7 +40,13 @@ SUITES=(
     ScreenDetectorExtendedTests
     WindowControllerResizeTests
     WindowControllerLifecycleTests
-    UIComponentTests
+    UIComponentTests/
+    WindowControllerSettingsHelpTests
+    TabCloseEdgeCaseTests
+    TabReorderingTests
+    TabStatePersistenceTests
+    CloseConfirmationTests
+    PinnedWindowVisibilityTests
     TabManagerTerminalIntegrationTests
     WindowControllerTabManagerIntegrationTests
     MaquakeE2ETests


### PR DESCRIPTION
## Summary

- **Tab rename fix**: centralize editing state in `TabManager.editingTabID` instead of per-view `@State isEditing` — prevents text input going to wrong tab when multiple tabs had local editing state. Also commits rename on focus loss.
- **Monitor switch positioning**: use `@Published panelWidth` with `.topLeading` ZStack alignment so terminal centering is computed from the known screen width, independent of the NSHostingView frame which can lag by one layout pass on screen transitions.
- **Settings/Help toggle**: clicking gear (or ⌘,) when settings tab is already active now closes it; same for help tab.
- API improvements: new `split`, `set-appearance` methods; pane resize handles and focus navigation; find bar support; expanded test coverage.
- Build: Xcode 26 libtool workaround for zig's misaligned .o files; ad-hoc signing fallback; dev install as `Macuake_dev`.

## Test plan

- [ ] Open multiple tabs, double-click to rename — verify text field appears on correct tab
- [ ] Rename tab, click elsewhere — verify name is committed on focus loss
- [ ] Open on monitor A, move cursor to monitor B, toggle — verify terminal is centered on first show
- [ ] Click settings gear to open settings, click again — verify it closes
- [ ] ⌘, toggles settings tab open/closed
- [ ] Split panes with ⌘D / ⌘⇧D, navigate with ⌘[ / ⌘], close with ⌘W